### PR TITLE
ci: Update to `actions/checkout@v4` from `v2` and `v3`.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         compiler: [gcc, clang]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: dependencies
       run: |
            sudo apt install gcc-10 g++-10 libgcc-10-dev libunwind8-dev
@@ -42,7 +42,7 @@ jobs:
       matrix:
         compiler: [gcc, clang]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: dependencies
       run: |
            pip3 install colorama
@@ -71,7 +71,7 @@ jobs:
       matrix:
         compiler: [msvc, clang, gcc]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Enable Developer Command Prompt
       uses: ilammy/msvc-dev-cmd@v1.10.0
     - name: dependencies

--- a/.github/workflows/cmake-integration.yml
+++ b/.github/workflows/cmake-integration.yml
@@ -8,7 +8,7 @@ jobs:
   test-linux-fetchcontent:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: test
       run: |
            tag=$(git rev-parse --abbrev-ref HEAD)
@@ -23,7 +23,7 @@ jobs:
   test-linux-findpackage:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: test
       run: |
            tag=$(git rev-parse --abbrev-ref HEAD)
@@ -41,7 +41,7 @@ jobs:
   test-linux-add_subdirectory:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: build
       run: |
            cd ..
@@ -56,7 +56,7 @@ jobs:
   test-macos-fetchcontent:
     runs-on: macos-13
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: test
       run: |
            tag=$(git rev-parse --abbrev-ref HEAD)
@@ -71,7 +71,7 @@ jobs:
   test-macos-findpackage:
     runs-on: macos-13
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: test
       run: |
            tag=$(git rev-parse --abbrev-ref HEAD)
@@ -90,7 +90,7 @@ jobs:
   test-macos-add_subdirectory:
     runs-on: macos-13
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: test
       run: |
            cd ..
@@ -105,7 +105,7 @@ jobs:
   test-mingw-fetchcontent:
     runs-on: windows-2022
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: test
       run: |
            $tag=$(git rev-parse --abbrev-ref HEAD)
@@ -120,7 +120,7 @@ jobs:
   test-mingw-add_subdirectory:
     runs-on: windows-2022
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: test
       run: |
            cd ..
@@ -134,7 +134,7 @@ jobs:
   test-windows-fetchcontent:
     runs-on: windows-2022
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Enable Developer Command Prompt
       uses: ilammy/msvc-dev-cmd@v1.10.0
     - name: test
@@ -151,7 +151,7 @@ jobs:
   test-windows-add_subdirectory:
     runs-on: windows-2022
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Enable Developer Command Prompt
       uses: ilammy/msvc-dev-cmd@v1.10.0
     - name: test

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -16,7 +16,7 @@ jobs:
           -DSPEEDTEST_DWARF5=On
         ]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: dependencies
       run: sudo apt install gcc-11 g++-11 libgcc-11-dev
     - name: build
@@ -46,7 +46,7 @@ jobs:
   #   matrix:
   #     compiler: [cl, clang++]
   # steps:
-  # - uses: actions/checkout@v2
+  # - uses: actions/checkout@v4
   # - name: Enable Developer Command Prompt
   #   uses: ilammy/msvc-dev-cmd@v1.10.0
   # - name: build

--- a/.github/workflows/sonarlint.yml
+++ b/.github/workflows/sonarlint.yml
@@ -12,7 +12,7 @@ jobs:
   sonarcloud:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         # Disabling shallow clone is recommended for improving relevancy of reporting
         fetch-depth: 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         compiler: [gcc, clang]
         shared: [--shared, ""]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: dependencies
       run: |
            sudo apt install gcc-10 g++-10 libgcc-10-dev libunwind8-dev
@@ -46,7 +46,7 @@ jobs:
         compiler: [gcc, clang]
         shared: [--shared, ""]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: libdwarf
       run: |
            cd ..
@@ -76,7 +76,7 @@ jobs:
         compiler: [msvc, clang, gcc]
         shared: [--shared, ""]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Enable Developer Command Prompt
       uses: ilammy/msvc-dev-cmd@v1.10.0
     - name: dependencies


### PR DESCRIPTION
This uses deprecated versions of Node within GitHub Actions.