### PR TITLE
Small fix to allow for compiling with Homebrew installed Clang on Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,7 +279,7 @@ target_compile_features(
     PRIVATE cxx_std_11
 )
 
-if(APPLE)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
   SET(CMAKE_C_ARCHIVE_FINISH   "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
   SET(CMAKE_CXX_ARCHIVE_FINISH "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
 endif()


### PR DESCRIPTION
When building with Clang installed with Homebrew:

```
-- The C compiler identification is Clang 17.0.6
-- The CXX compiler identification is Clang 17.0.6
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /opt/homebrew/opt/llvm/bin/clang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /opt/homebrew/opt/llvm/bin/clang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
```

I get the following error:

```
/opt/homebrew/opt/llvm/bin/llvm-ranlib: error: Invalid option: '-no_warning_for_no_symbols'
make[2]: *** [_deps/zstd-build/lib/libzstd.a] Error 1
make[2]: *** Deleting file `_deps/zstd-build/lib/libzstd.a'
make[1]: *** [_deps/zstd-build/lib/CMakeFiles/libzstd_static.dir/all] Error 2
make: *** [all] Error 2
```

If I instead build with AppleClang:

```
-- The C compiler identification is AppleClang 15.0.0.15000100
-- The CXX compiler identification is AppleClang 15.0.0.15000100
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
```

It works as expected.

Source of the problem is found at `CMakeLists.txt:282`:

```CMake
if(APPLE)
  SET(CMAKE_C_ARCHIVE_FINISH   "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
  SET(CMAKE_CXX_ARCHIVE_FINISH "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
endif()
```

Changing it to check specifically for AppleClang appears to fix the problem for me:

```CMake
if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
  SET(CMAKE_C_ARCHIVE_FINISH   "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
  SET(CMAKE_CXX_ARCHIVE_FINISH "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
endif()
```