### PR TITLE
ci: Update `ilammy/msvc-dev-cmd` to 1.13 from 1.10.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Enable Developer Command Prompt
-      uses: ilammy/msvc-dev-cmd@v1.10.0
+      uses: ilammy/msvc-dev-cmd@v1.13.0
     - name: dependencies
       run: |
            pip3 install colorama

--- a/.github/workflows/cmake-integration.yml
+++ b/.github/workflows/cmake-integration.yml
@@ -198,7 +198,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Enable Developer Command Prompt
-      uses: ilammy/msvc-dev-cmd@v1.10.0
+      uses: ilammy/msvc-dev-cmd@v1.13.0
     - name: test
       run: |
            $tag=$(git rev-parse --abbrev-ref HEAD)
@@ -219,7 +219,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Enable Developer Command Prompt
-      uses: ilammy/msvc-dev-cmd@v1.10.0
+      uses: ilammy/msvc-dev-cmd@v1.13.0
     - name: test
       run: |
            $tag=$(git rev-parse --abbrev-ref HEAD)
@@ -248,7 +248,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Enable Developer Command Prompt
-      uses: ilammy/msvc-dev-cmd@v1.10.0
+      uses: ilammy/msvc-dev-cmd@v1.13.0
     - name: test
       run: |
            cd ..

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -48,7 +48,7 @@ jobs:
   # steps:
   # - uses: actions/checkout@v4
   # - name: Enable Developer Command Prompt
-  #   uses: ilammy/msvc-dev-cmd@v1.10.0
+  #   uses: ilammy/msvc-dev-cmd@v1.13.0
   # - name: build
   #   run: |
   #        mkdir -p build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Enable Developer Command Prompt
-      uses: ilammy/msvc-dev-cmd@v1.10.0
+      uses: ilammy/msvc-dev-cmd@v1.13.0
     - name: dependencies
       run: |
            pip3 install colorama


### PR DESCRIPTION
This should remove most of the warnings about using older versions of NodeJS.