### PR TITLE
Tweaks from clang-tidy

### DIFF
--- a/include/cpptrace/cpptrace.hpp
+++ b/include/cpptrace/cpptrace.hpp
@@ -413,7 +413,7 @@ namespace cpptrace {
         mutable std::string message_value;
     public:
         explicit nested_exception(
-            std::exception_ptr exception_ptr,
+            const std::exception_ptr& exception_ptr,
             raw_trace&& trace = detail::get_raw_trace_and_absorb()
         ) noexcept
             : lazy_exception(std::move(trace)), ptr(exception_ptr) {}

--- a/include/cpptrace/cpptrace.hpp
+++ b/include/cpptrace/cpptrace.hpp
@@ -293,7 +293,7 @@ namespace cpptrace {
     // Interface for a traced exception object
     class CPPTRACE_EXPORT exception : public std::exception {
     public:
-        virtual const char* what() const noexcept = 0;
+        const char* what() const noexcept override = 0;
         virtual const char* message() const noexcept = 0;
         virtual const stacktrace& trace() const noexcept = 0;
     };

--- a/src/binary/mach-o.hpp
+++ b/src/binary/mach-o.hpp
@@ -372,7 +372,7 @@ namespace detail {
         // produce information similar to dsymutil -dump-debug-map
         static void print_debug_map(const debug_map& debug_map) {
             for(const auto& entry : debug_map) {
-                std::cout<<entry.first<<": "<<std::endl;
+                std::cout<<entry.first<<": "<< '\n';
                 for(const auto& symbol : entry.second) {
                     std::cerr
                         << "    "
@@ -383,7 +383,7 @@ namespace detail {
                         << " "
                         << symbol.size
                         << std::dec
-                        << std::endl;
+                        << '\n';
                 }
             }
         }

--- a/src/cpptrace.cpp
+++ b/src/cpptrace.cpp
@@ -174,10 +174,10 @@ namespace cpptrace {
         ) {
             detail::enable_virtual_terminal_processing_if_needed();
         }
-        stream<<(header ? header : "Stack trace (most recent call first):")<<std::endl;
+        stream<<(header ? header : "Stack trace (most recent call first):") << '\n';
         std::size_t counter = 0;
         if(frames.empty()) {
-            stream<<"<empty trace>"<<std::endl;
+            stream<<"<empty trace>" << '\n';
             return;
         }
         const auto reset   = color ? ESC "0m" : "";
@@ -237,7 +237,7 @@ namespace cpptrace {
                 }
             }
             if(newline_at_end || &frame != &frames.back()) {
-                stream << std::endl;
+                stream << '\n';
             }
             counter++;
         }

--- a/src/symbols/symbols_with_libdwarf.cpp
+++ b/src/symbols/symbols_with_libdwarf.cpp
@@ -186,7 +186,7 @@ namespace libdwarf {
         }
 
         CPPTRACE_FORCE_NO_INLINE_FOR_PROFILING
-        ~dwarf_resolver() {
+        ~dwarf_resolver() override {
             // TODO: Maybe redundant since dwarf_finish(dbg); will clean up the line stuff anyway but may as well just
             // for thoroughness
             for(auto& entry : line_contexts) {

--- a/src/symbols/symbols_with_libdwarf.cpp
+++ b/src/symbols/symbols_with_libdwarf.cpp
@@ -928,7 +928,7 @@ namespace libdwarf {
         optional<std::unordered_map<std::string, uint64_t>> symbols;
         std::unique_ptr<symbol_resolver> resolver;
 
-        target_object(std::string object_path) : object_path(object_path) {}
+        target_object(std::string object_path) : object_path(std::move(object_path)) {}
 
         std::unique_ptr<symbol_resolver>& get_resolver() {
             if(!resolver) {

--- a/src/symbols/symbols_with_libdwarf.cpp
+++ b/src/symbols/symbols_with_libdwarf.cpp
@@ -1003,7 +1003,7 @@ namespace libdwarf {
             // get symbol entries from debug map, as well as the various object files used to make this binary
             for(auto& entry : source_debug_map) {
                 // object it came from
-                target_objects.push_back({std::move(entry.first)});
+                target_objects.push_back({entry.first});
                 // push the symbols
                 auto& map_entry_symbols = entry.second;
                 symbols.reserve(symbols.size() + map_entry_symbols.size());

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -280,7 +280,7 @@ namespace detail {
             return *this;
         }
 
-        void swap(optional& other) {
+        void swap(optional& other) noexcept {
             if(holds_value && other.holds_value) {
                 std::swap(uvalue, other.uvalue);
             } else if(holds_value && !other.holds_value) {

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -409,7 +409,7 @@ namespace detail {
         optional<D> deleter;
     public:
         raii_wrapper(T obj, D deleter) : obj(obj), deleter(deleter) {}
-        raii_wrapper(raii_wrapper&& other) noexcept : obj(std::move(other.obj)), deleter(other.deleter) {
+        raii_wrapper(raii_wrapper&& other) noexcept : obj(std::move(other.obj)), deleter(std::move(other.deleter)) {
             other.deleter = nullopt;
         }
         raii_wrapper(const raii_wrapper&) = delete;


### PR DESCRIPTION
This is (perhaps) mainly for discussion as I saw you removed `clang-tidy` checks last year. These fix a variety of minor things.

With one of the options that I was using, these still remain:

```
/Users/bruce/Development/custodian/cpptrace/src/symbols/../utils/utils.hpp:235:22: warning: noexcept specifier on the move constructor evaluates to 'false' [performance-noexcept-move-constructor]
  235 |             noexcept(std::is_nothrow_move_constructible<T>::value)
      |                      ^
/Users/bruce/Development/custodian/cpptrace/src/symbols/../utils/utils.hpp:250:64: warning: noexcept specifier on the move assignment operator evaluates to 'false' [performance-noexcept-move-constructor]
  250 |             noexcept(std::is_nothrow_move_assignable<T>::value && std::is_nothrow_move_constructible<T>::value)
      |                                                                ^
```
