### PR TITLE
Use `defined(CPPTRACE_HAS_CXX_EXCEPTION_TYPE)`.

### DIFF
--- a/src/utils/exception_type.hpp
+++ b/src/utils/exception_type.hpp
@@ -4,7 +4,7 @@
 #include <string>
 
 // libstdc++ and libc++
-#if CPPTRACE_HAS_CXX_EXCEPTION_TYPE && defined(__GLIBCXX__) || defined(__GLIBCPP__) || defined(_LIBCPP_VERSION)
+#if defined(CPPTRACE_HAS_CXX_EXCEPTION_TYPE) && defined(__GLIBCXX__) || defined(__GLIBCPP__) || defined(_LIBCPP_VERSION)
  #include <cxxabi.h>
 #endif
 
@@ -13,7 +13,7 @@
 namespace cpptrace {
 namespace detail {
     inline std::string exception_type_name() {
-        #if CPPTRACE_HAS_CXX_EXCEPTION_TYPE && defined(__GLIBCXX__) || defined(__GLIBCPP__) || defined(_LIBCPP_VERSION)
+        #if defined(CPPTRACE_HAS_CXX_EXCEPTION_TYPE) && defined(__GLIBCXX__) || defined(__GLIBCPP__) || defined(_LIBCPP_VERSION)
         const std::type_info* t = abi::__cxa_current_exception_type();
         return t ? detail::demangle(t->name()) : "<unknown>";
         #else


### PR DESCRIPTION
This is set by the build system when it is available and not set when not available (and not set to 1/0 respectively).

The current code can generate a warning when this preprocessor definition is not defined.