### PR TITLE
Improve zstd handling

### DIFF
--- a/cmake/Findzstd.cmake
+++ b/cmake/Findzstd.cmake
@@ -1,0 +1,51 @@
+# Libdwarf needs zstd, cpptrace doesn't, and libdwarf has its own Findzstd but it doesn't define zstd::libzstd_static /
+# zstd::libzstd_shared targets which leads to issues, necessitating a find_dependency(zstd) in cpptrace's cmake config
+# and in order to support non-cmake-module installs we need to provide a Findzstd script.
+# https://github.com/jeremy-rifkin/cpptrace/issues/112
+
+# This will define
+# zstd_FOUND
+# zstd_INCLUDE_DIR
+# zstd_LIBRARY
+
+find_path(zstd_INCLUDE_DIR NAMES zstd.h)
+
+find_library(zstd_LIBRARY_DEBUG NAMES zstdd zstd_staticd)
+find_library(zstd_LIBRARY_RELEASE NAMES zstd zstd_static)
+
+include(SelectLibraryConfigurations)
+SELECT_LIBRARY_CONFIGURATIONS(zstd)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(
+  zstd DEFAULT_MSG
+  zstd_LIBRARY zstd_INCLUDE_DIR
+)
+
+if(zstd_FOUND)
+  message(STATUS "Found Zstd: ${zstd_LIBRARY}")
+endif()
+
+mark_as_advanced(zstd_INCLUDE_DIR zstd_LIBRARY)
+
+if(zstd_FOUND)
+  # just defining them the same... cmake will figure it out
+  if(NOT TARGET zstd::libzstd_static)
+    add_library(zstd::libzstd_static UNKNOWN IMPORTED)
+    set_target_properties(
+      zstd::libzstd_static
+      PROPERTIES
+      IMPORTED_LOCATION "${zstd_LIBRARIES}"
+      INTERFACE_INCLUDE_DIRECTORIES "${zstd_INCLUDE_DIR}"
+    )
+  endif()
+  if(NOT TARGET zstd::libzstd_shared)
+    add_library(zstd::libzstd_shared UNKNOWN IMPORTED)
+    set_target_properties(
+      zstd::libzstd_shared
+      PROPERTIES
+      IMPORTED_LOCATION "${zstd_LIBRARIES}"
+      INTERFACE_INCLUDE_DIRECTORIES "${zstd_INCLUDE_DIR}"
+    )
+  endif()
+endif()

--- a/cmake/InstallRules.cmake
+++ b/cmake/InstallRules.cmake
@@ -63,7 +63,13 @@ install(
 )
 
 # Findzstd.cmake
-install(FILES "${PROJECT_SOURCE_DIR}/cmake/Findzstd.cmake" DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${package_name}")
+# vcpkg doesn't like anything being put in share/, which is where this goes apparently on their setup
+if(NOT CPPTRACE_VCPKG)
+  install(
+    FILES "${PROJECT_SOURCE_DIR}/cmake/Findzstd.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${package_name}"
+  )
+endif()
 
 # support packaging library
 if(PROJECT_IS_TOP_LEVEL)

--- a/cmake/InstallRules.cmake
+++ b/cmake/InstallRules.cmake
@@ -62,6 +62,9 @@ install(
   COMPONENT ${package_name}-development
 )
 
+# Findzstd.cmake
+install(FILES "${PROJECT_SOURCE_DIR}/cmake/Findzstd.cmake" DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${package_name}")
+
 # support packaging library
 if(PROJECT_IS_TOP_LEVEL)
   include(CPack)

--- a/cmake/in/cpptrace-config-cmake.in
+++ b/cmake/in/cpptrace-config-cmake.in
@@ -4,11 +4,16 @@
 # Dependencies
 if(@CPPTRACE_GET_SYMBOLS_WITH_LIBDWARF@)
   include(CMakeFindDependencyMacro)
-  set(CMAKE_MODULE_PATH_OLD "${CMAKE_MODULE_PATH}")
-  set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_LIST_DIR}")
-  find_dependency(zstd)
-  set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH_OLD}")
-  unset(CMAKE_MODULE_PATH_OLD)
+  # we don't go the Findzstd.cmake route on vcpkg
+  if(@CPPTRACE_VCPKG@)
+    find_dependency(zstd CONFIG REQUIRED)
+  else()
+    set(CMAKE_MODULE_PATH_OLD "${CMAKE_MODULE_PATH}")
+    set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_LIST_DIR}")
+    find_dependency(zstd)
+    set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH_OLD}")
+    unset(CMAKE_MODULE_PATH_OLD)
+  endif()
   find_dependency(libdwarf REQUIRED)
 endif()
 

--- a/cmake/in/cpptrace-config-cmake.in
+++ b/cmake/in/cpptrace-config-cmake.in
@@ -4,6 +4,11 @@
 # Dependencies
 if(@CPPTRACE_GET_SYMBOLS_WITH_LIBDWARF@)
   include(CMakeFindDependencyMacro)
+  set(CMAKE_MODULE_PATH_OLD "${CMAKE_MODULE_PATH}")
+  set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_LIST_DIR}")
+  find_dependency(zstd)
+  set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH_OLD}")
+  unset(CMAKE_MODULE_PATH_OLD)
   find_dependency(libdwarf REQUIRED)
 endif()
 

--- a/cmake/in/cpptrace-config-cmake.in
+++ b/cmake/in/cpptrace-config-cmake.in
@@ -4,7 +4,6 @@
 # Dependencies
 if(@CPPTRACE_GET_SYMBOLS_WITH_LIBDWARF@)
   include(CMakeFindDependencyMacro)
-  find_dependency(zstd REQUIRED)
   find_dependency(libdwarf REQUIRED)
 endif()
 


### PR DESCRIPTION
This PR adds a Findzstd.cmake script to cpptrace's install so that `find_dependency(zstd)` can succeed on installations that don't include zstdConfig.cmake/zstd-config.cmake.

The reason `find_dependency(zstd)` is needed in cpptrace's config, despite `find_dependency(zstd)` also being in libdwarf's cmake and cpptrace not needing zstd, is that libdwarf's cmake doesn't define `zstd::libzstd_static` / `zstd::libzstd_shared` targets.

This should fix #112.