### PR TITLE
Fix missing cxxabi.h include on Windows when using libc++

### DIFF
--- a/src/utils/exception_type.hpp
+++ b/src/utils/exception_type.hpp
@@ -4,7 +4,7 @@
 #include <string>
 
 // libstdc++ and libc++
-#if defined(CPPTRACE_HAS_CXX_EXCEPTION_TYPE) && defined(__GLIBCXX__) || defined(__GLIBCPP__) || defined(_LIBCPP_VERSION)
+#if defined(CPPTRACE_HAS_CXX_EXCEPTION_TYPE) && (defined(__GLIBCXX__) || defined(__GLIBCPP__) || defined(_LIBCPP_VERSION))
  #include <cxxabi.h>
 #endif
 
@@ -13,7 +13,7 @@
 namespace cpptrace {
 namespace detail {
     inline std::string exception_type_name() {
-        #if defined(CPPTRACE_HAS_CXX_EXCEPTION_TYPE) && defined(__GLIBCXX__) || defined(__GLIBCPP__) || defined(_LIBCPP_VERSION)
+        #if defined(CPPTRACE_HAS_CXX_EXCEPTION_TYPE) && (defined(__GLIBCXX__) || defined(__GLIBCPP__) || defined(_LIBCPP_VERSION))
         const std::type_info* t = abi::__cxa_current_exception_type();
         return t ? detail::demangle(t->name()) : "<unknown>";
         #else


### PR DESCRIPTION
Make operator precedence explicit so the `CPPTRACE_HAS_CXX_EXCEPTION_TYPE` define is a dominant switch to use cxxabi.h, rather than one that only applies when `__GLIBCXX__` is defined.

Fixes https://github.com/jeremy-rifkin/cpptrace/issues/121