### PR TITLE
fix compile error in gcc 4.8.5.

### DIFF
--- a/src/symbols/symbols_with_libdwarf.cpp
+++ b/src/symbols/symbols_with_libdwarf.cpp
@@ -44,7 +44,7 @@ namespace libdwarf {
                 // .emplace needed, for some reason .insert tries to copy <= gcc 7.2
                 return resolver_map.emplace(object_name, std::move(resolver_object)).first->second.get();
             } else {
-                return resolver_object;
+                return std::move(resolver_object);
             }
         }
     }
@@ -56,11 +56,10 @@ namespace libdwarf {
             // most recent call first
             if(!entry.inlines.empty()) {
                 // insert in reverse order
-                final_trace.insert(
-                    final_trace.end(),
-                    std::make_move_iterator(entry.inlines.rbegin()),
-                    std::make_move_iterator(entry.inlines.rend())
-                );
+                for(auto iter = entry.inlines.rbegin(); iter != entry.inlines.rend(); ++iter){
+                    auto& val = *iter; //const stacktrace_frame&
+                    final_trace.emplace_back(val);
+                }
             }
             final_trace.push_back(std::move(entry.frame));
             if(!entry.inlines.empty()) {

--- a/src/symbols/symbols_with_libdwarf.cpp
+++ b/src/symbols/symbols_with_libdwarf.cpp
@@ -44,7 +44,7 @@ namespace libdwarf {
                 // .emplace needed, for some reason .insert tries to copy <= gcc 7.2
                 return resolver_map.emplace(object_name, std::move(resolver_object)).first->second.get();
             } else {
-                return std::move(resolver_object);
+                return maybe_owned<symbol_resolver>{std::move(resolver_object)};
             }
         }
     }

--- a/src/symbols/symbols_with_libdwarf.cpp
+++ b/src/symbols/symbols_with_libdwarf.cpp
@@ -52,16 +52,17 @@ namespace libdwarf {
     }
 
     // flatten trace with inlines
-    std::vector<stacktrace_frame> flatten_inlines(const std::vector<frame_with_inlines>& trace) {
+    std::vector<stacktrace_frame> flatten_inlines(std::vector<frame_with_inlines>& trace) {
         std::vector<stacktrace_frame> final_trace;
         for(const auto& entry : trace) {
             // most recent call first
             if(!entry.inlines.empty()) {
                 // insert in reverse order
-                for(auto iter = entry.inlines.rbegin(); iter != entry.inlines.rend(); ++iter){
-                    auto& val = *iter; //const stacktrace_frame&
-                    final_trace.emplace_back(val);
-                }
+                final_trace.insert(
+                    final_trace.end(),
+                    std::make_move_iterator(entry.inlines.rbegin()),
+                    std::make_move_iterator(entry.inlines.rend())
+                );
             }
             final_trace.push_back(std::move(entry.frame));
             if(!entry.inlines.empty()) {

--- a/src/symbols/symbols_with_libdwarf.cpp
+++ b/src/symbols/symbols_with_libdwarf.cpp
@@ -44,6 +44,8 @@ namespace libdwarf {
                 // .emplace needed, for some reason .insert tries to copy <= gcc 7.2
                 return resolver_map.emplace(object_name, std::move(resolver_object)).first->second.get();
             } else {
+                // gcc cannot handle the following logic properly in <= gcc 5.1, so the type to be constructed is explicitly specified. 
+                // See also:https://godbolt.org/z/9oWdWjbf8
                 return maybe_owned<symbol_resolver>{std::move(resolver_object)};
             }
         }


### PR DESCRIPTION
I attempted to build cpptrace in a Centos 7 (gcc-c++ 4.8.5) environment using CMake with default parameters and encountered the following compilation errors:

```
cpptrace/src/symbols/symbols_with_libdwarf.cpp: 47: 24: error: cannot bind 'std::unique_ptr<cpptrace::detail::libdwarf::symbol_resolver>' lvalue to 'std: unique_ptr<cpptrace: detail::libdwarf::symbol_resolver>&&'

return resolver_object;
```
The code related to this error is:

https://github.com/jeremy-rifkin/cpptrace/blob/06226ee2aa6a615a63af9d73d69e522c10093dd2/src/symbols/symbols_with_libdwarf.cpp#L35-L50

It appears that line 47 transfers ownership of the object to an external entity, but in the aforementioned gcc version, there are errors related to move operations. Therefore, I added this part. 

```
cpptrace/src/symbols/symbols_with_libdwarf. cpp: 64: 17: required from here
/usr/include/c++/4.8.2/bits/stl_iterator.h:963:37: error invalid initialization of reference of type 'std::move_iterator<std::reverse_iterator<__gnu_cxx::__normal_iterator<const cpptrace::stacktrace_frame*, std: vector<cpptrace::stacktrace_frame> >>>::reference aka cpptrace::stacktrace_frame&&' from expression of type 'std::remove_reference<const cpptrace::stacktrace_frame&>::type aka {const cpptrace::stacktrace_frame}'

return std::move(*_M_current); 
```
The code related to this error is:

https://github.com/jeremy-rifkin/cpptrace/blob/06226ee2aa6a615a63af9d73d69e522c10093dd2/src/symbols/symbols_with_libdwarf.cpp#L53-L64

I'm not sure why it doesn't work properly on the aforementioned gcc version, so I changed the approach. At least it passed the compilation.


In summary, I tried to fix these compilation errors, and finally, it seems to be running normally. 