### PR TITLE
Fix trace generation for cpptrace exception objects on armv7hf

### DIFF
--- a/include/cpptrace/cpptrace.hpp
+++ b/include/cpptrace/cpptrace.hpp
@@ -302,8 +302,8 @@ namespace cpptrace {
             void clear();
         };
 
-        CPPTRACE_EXPORT raw_trace get_raw_trace_and_absorb(std::size_t skip, std::size_t max_depth) noexcept;
-        CPPTRACE_EXPORT raw_trace get_raw_trace_and_absorb(std::size_t skip = 0) noexcept;
+        CPPTRACE_EXPORT raw_trace get_raw_trace_and_absorb(std::size_t skip, std::size_t max_depth);
+        CPPTRACE_EXPORT raw_trace get_raw_trace_and_absorb(std::size_t skip = 0);
     }
 
     // Interface for a traced exception object
@@ -323,7 +323,7 @@ namespace cpptrace {
     public:
         explicit lazy_exception(
             raw_trace&& trace = detail::get_raw_trace_and_absorb()
-        ) noexcept : trace_holder(std::move(trace)) {}
+        ) : trace_holder(std::move(trace)) {}
         // std::exception
         const char* what() const noexcept override;
         // cpptrace::exception

--- a/src/cpptrace.cpp
+++ b/src/cpptrace.cpp
@@ -457,7 +457,7 @@ namespace cpptrace {
         }
 
         CPPTRACE_FORCE_NO_INLINE
-        raw_trace get_raw_trace_and_absorb(std::size_t skip, std::size_t max_depth) noexcept {
+        raw_trace get_raw_trace_and_absorb(std::size_t skip, std::size_t max_depth) {
             try {
                 return generate_raw_trace(skip + 1, max_depth);
             } catch(const std::exception& e) {
@@ -474,7 +474,7 @@ namespace cpptrace {
         }
 
         CPPTRACE_FORCE_NO_INLINE
-        raw_trace get_raw_trace_and_absorb(std::size_t skip) noexcept {
+        raw_trace get_raw_trace_and_absorb(std::size_t skip) {
             return get_raw_trace_and_absorb(skip + 1, SIZE_MAX);
         }
 


### PR DESCRIPTION
 noexcept on get_raw_trace_and_absorb seems to somehow interfere with unwinding on armv7hf, possibly due to unwind tables not being generated for the function. Fixes #134.