### PR TITLE
Improve compilation times on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,7 +248,7 @@ target_sources(
     src/unwind/unwind_with_winapi.cpp
     src/utils/microfmt.cpp
     src/utils/utils.cpp
-    src/platform/dbghelp_syminit_manager.cpp
+    $<$<BOOL:${WIN32}>:src/platform/dbghelp_syminit_manager.cpp>
 )
 
 target_include_directories(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,9 @@ target_sources(
     src/unwind/unwind_with_nothing.cpp
     src/unwind/unwind_with_unwind.cpp
     src/unwind/unwind_with_winapi.cpp
+    src/utils/microfmt.cpp
+    src/utils/utils.cpp
+    src/platform/dbghelp_syminit_manager.cpp
 )
 
 target_include_directories(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,7 +248,7 @@ target_sources(
     src/unwind/unwind_with_winapi.cpp
     src/utils/microfmt.cpp
     src/utils/utils.cpp
-    $<$<BOOL:${WIN32}>:src/platform/dbghelp_syminit_manager.cpp>
+    src/platform/dbghelp_syminit_manager.cpp
 )
 
 target_include_directories(

--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ Cpptrace provides functionality beyond what the standard library provides and wh
 - Resolving function parameter types
 - Providing traced exception objects
 - Providing an API for signal-safe stacktrace generation
+- Providing a way to retrieve stack traces from arbitrary exceptions, not just special cpptrace traced exception
+  objects. This is a feature coming to C++26, but cpptrace provides a solution for C++11.
 
 ## What does cpptrace have over other C++ stacktrace libraries?
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(cpptrace)
 target_link_libraries(your_target cpptrace::cpptrace)
 
-# On windows copy cpptrace.dll to the same directory as the executable for your_target
+# Needed for shared library builds on windows:  copy cpptrace.dll to the same directory as the
+# executable for your_target
 if(WIN32)
   add_custom_command(
     TARGET your_target POST_BUILD

--- a/cmake/has_stackwalk.cpp
+++ b/cmake/has_stackwalk.cpp
@@ -1,3 +1,4 @@
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <dbghelp.h>
 

--- a/src/binary/module_base.cpp
+++ b/src/binary/module_base.cpp
@@ -1,10 +1,9 @@
 #include "binary/module_base.hpp"
 
-#include "utils/common.hpp"
+#include "platform/platform.hpp"
 #include "utils/utils.hpp"
 
 #include <string>
-#include <vector>
 #include <mutex>
 #include <unordered_map>
 
@@ -17,7 +16,6 @@
   #include "binary/elf.hpp"
  #endif
 #elif IS_WINDOWS
- #include <windows.h>
  #include "binary/pe.hpp"
 #endif
 

--- a/src/binary/module_base.hpp
+++ b/src/binary/module_base.hpp
@@ -1,7 +1,6 @@
 #ifndef IMAGE_MODULE_BASE_HPP
 #define IMAGE_MODULE_BASE_HPP
 
-#include "utils/common.hpp"
 #include "utils/utils.hpp"
 
 #include <cstdint>

--- a/src/binary/object.cpp
+++ b/src/binary/object.cpp
@@ -1,6 +1,6 @@
 #include "binary/object.hpp"
 
-#include "utils/common.hpp"
+#include "platform/platform.hpp"
 #include "utils/utils.hpp"
 #include "binary/module_base.hpp"
 
@@ -16,6 +16,7 @@
   #include <link.h> // needed for dladdr1's link_map info
  #endif
 #elif IS_WINDOWS
+ #define WIN32_LEAN_AND_MEAN
  #include <windows.h>
 #endif
 

--- a/src/binary/object.hpp
+++ b/src/binary/object.hpp
@@ -1,14 +1,16 @@
 #ifndef OBJECT_HPP
 #define OBJECT_HPP
 
-#include "utils/common.hpp"
-#include "utils/utils.hpp"
-#include "binary/module_base.hpp"
-
-#include <string>
 #include <vector>
+#include <cstdint>
 
 namespace cpptrace {
+
+struct object_frame;
+struct safe_object_frame;
+
+using frame_ptr = std::uintptr_t;
+
 namespace detail {
     object_frame get_frame_object_info(frame_ptr address);
 

--- a/src/binary/pe.cpp
+++ b/src/binary/pe.cpp
@@ -1,16 +1,16 @@
 #include "binary/pe.hpp"
 
-#include "utils/common.hpp"
+#include "platform/platform.hpp"
 #include "utils/error.hpp"
 #include "utils/utils.hpp"
 
 #if IS_WINDOWS
 #include <array>
-#include <cstddef>
 #include <cstdio>
 #include <cstring>
 #include <string>
 
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 namespace cpptrace {

--- a/src/binary/pe.hpp
+++ b/src/binary/pe.hpp
@@ -1,7 +1,7 @@
 #ifndef PE_HPP
 #define PE_HPP
 
-#include "utils/common.hpp"
+#include "platform/platform.hpp"
 #include "utils/utils.hpp"
 
 #if IS_WINDOWS

--- a/src/cpptrace.cpp
+++ b/src/cpptrace.cpp
@@ -5,7 +5,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
-#include <new>
+#include <iostream>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -16,6 +16,7 @@
 #include "demangle/demangle.hpp"
 #include "platform/exception_type.hpp"
 #include "utils/common.hpp"
+#include "utils/microfmt.hpp"
 #include "utils/utils.hpp"
 #include "binary/object.hpp"
 #include "binary/safe_dl.hpp"

--- a/src/cpptrace.cpp
+++ b/src/cpptrace.cpp
@@ -6,6 +6,7 @@
 #include <cstdio>
 #include <cstring>
 #include <iostream>
+#include <new>
 #include <sstream>
 #include <stdexcept>
 #include <string>

--- a/src/demangle/demangle_with_winapi.cpp
+++ b/src/demangle/demangle_with_winapi.cpp
@@ -4,6 +4,7 @@
 
 #include <string>
 
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <dbghelp.h>
 

--- a/src/from_current.cpp
+++ b/src/from_current.cpp
@@ -6,305 +6,327 @@
 #include <typeinfo>
 
 #include "platform/platform.hpp"
-#include "utils/common.hpp"
 #include "utils/microfmt.hpp"
-#include "utils/utils.hpp"
 
 #ifndef _MSC_VER
- #include <array>
- #include <string.h>
- #if IS_WINDOWS
-  #include <windows.h>
- #else
-  #include <sys/mman.h>
-  #include <unistd.h>
-  #if IS_APPLE
-   #include <mach/mach.h>
-   #include <mach/mach_vm.h>
-  #else
-   #include <fstream>
-   #include <iomanip>
-  #endif
- #endif
+#include <string.h>
+#if IS_WINDOWS
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#else
+#include <sys/mman.h>
+#include <unistd.h>
+#if IS_APPLE
+#include <mach/mach.h>
+#include <mach/mach_vm.h>
+#else
+#include <fstream>
+#include <ios>
+#endif
+#endif
 #endif
 
 namespace cpptrace {
-    namespace detail {
-        thread_local lazy_trace_holder current_exception_trace;
+namespace detail {
+thread_local lazy_trace_holder current_exception_trace;
 
-        CPPTRACE_FORCE_NO_INLINE void collect_current_trace(std::size_t skip) {
-            current_exception_trace = lazy_trace_holder(cpptrace::generate_raw_trace(skip + 1));
-        }
-
-        #ifndef _MSC_VER
-        // set only once by do_prepare_unwind_interceptor
-        char (*intercept_unwind_handler)(std::size_t) = nullptr;
-
-        CPPTRACE_FORCE_NO_INLINE
-        bool intercept_unwind(const std::type_info*, const std::type_info*, void**, unsigned) {
-            if(intercept_unwind_handler) {
-                intercept_unwind_handler(1);
-            }
-            return false;
-        }
-
-        CPPTRACE_FORCE_NO_INLINE
-        bool unconditional_exception_unwind_interceptor(const std::type_info*, const std::type_info*, void**, unsigned) {
-            collect_current_trace(1);
-            return false;
-        }
-
-        using do_catch_fn = decltype(intercept_unwind);
-
-        unwind_interceptor::~unwind_interceptor() = default;
-        unconditional_unwind_interceptor::~unconditional_unwind_interceptor() = default;
-
-        #if IS_LIBSTDCXX
-            constexpr size_t vtable_size = 11;
-        #elif IS_LIBCXX
-            constexpr size_t vtable_size = 10;
-        #else
-            #warning "Cpptrace from_current: Unrecognized C++ standard library, from_current() won't be supported"
-            constexpr size_t vtable_size = 0;
-        #endif
-
-        #if IS_WINDOWS
-        int get_page_size() {
-            SYSTEM_INFO info;
-            GetSystemInfo(&info);
-            return info.dwPageSize;
-        }
-        constexpr auto memory_readonly = PAGE_READONLY;
-        constexpr auto memory_readwrite = PAGE_READWRITE;
-        int mprotect_page_and_return_old_protections(void* page, int page_size, int protections) {
-            DWORD old_protections;
-            if(!VirtualProtect(page, page_size, protections, &old_protections)) {
-                throw std::runtime_error(
-                    microfmt::format(
-                        "VirtualProtect call failed: {}",
-                        std::system_error(GetLastError(), std::system_category()).what()
-                    )
-                );
-            }
-            return old_protections;
-        }
-        void mprotect_page(void* page, int page_size, int protections) {
-            mprotect_page_and_return_old_protections(page, page_size, protections);
-        }
-        void* allocate_page(int page_size) {
-            auto page = VirtualAlloc(nullptr, page_size, MEM_COMMIT | MEM_RESERVE, memory_readwrite);
-            if(!page) {
-                throw std::runtime_error(
-                    microfmt::format(
-                        "VirtualAlloc call failed: {}",
-                        std::system_error(GetLastError(), std::system_category()).what()
-                    )
-                );
-            }
-            return page;
-        }
-        #else
-        int get_page_size() {
-            return getpagesize();
-        }
-        constexpr auto memory_readonly = PROT_READ;
-        constexpr auto memory_readwrite = PROT_READ | PROT_WRITE;
-        #if IS_APPLE
-        int get_page_protections(void* page) {
-            // https://stackoverflow.com/a/12627784/15675011
-            mach_vm_size_t vmsize;
-            mach_vm_address_t address = (mach_vm_address_t)page;
-            vm_region_basic_info_data_t info;
-            mach_msg_type_number_t info_count =
-                sizeof(size_t) == 8 ? VM_REGION_BASIC_INFO_COUNT_64 : VM_REGION_BASIC_INFO_COUNT;
-            memory_object_name_t object;
-            kern_return_t status = mach_vm_region(
-                mach_task_self(),
-                &address,
-                &vmsize,
-                VM_REGION_BASIC_INFO,
-                (vm_region_info_t)&info,
-                &info_count,
-                &object
-            );
-            if(status == KERN_INVALID_ADDRESS) {
-                throw std::runtime_error("vm_region failed with KERN_INVALID_ADDRESS");
-            }
-            int perms = 0;
-            if(info.protection & VM_PROT_READ) {
-                perms |= PROT_READ;
-            }
-            if(info.protection & VM_PROT_WRITE) {
-                perms |= PROT_WRITE;
-            }
-            if(info.protection & VM_PROT_EXECUTE) {
-                perms |= PROT_EXEC;
-            }
-            return perms;
-        }
-        #else
-        int get_page_protections(void* page) {
-            auto page_addr = reinterpret_cast<uintptr_t>(page);
-            std::ifstream stream("/proc/self/maps");
-            stream>>std::hex;
-            while(!stream.eof()) {
-                uintptr_t start;
-                uintptr_t stop;
-                stream>>start;
-                stream.ignore(1); // dash
-                stream>>stop;
-                if(stream.eof()) {
-                    break;
-                }
-                if(stream.fail()) {
-                    throw std::runtime_error("Failure reading /proc/self/maps");
-                }
-                if(page_addr >= start && page_addr < stop) {
-                    stream.ignore(1); // space
-                    char r, w, x; // there's a private/shared flag after these but we don't need it
-                    stream>>r>>w>>x;
-                    if(stream.fail() || stream.eof()) {
-                        throw std::runtime_error("Failure reading /proc/self/maps");
-                    }
-                    int perms = 0;
-                    if(r == 'r') {
-                        perms |= PROT_READ;
-                    }
-                    if(w == 'w') {
-                        perms |= PROT_WRITE;
-                    }
-                    if(x == 'x') {
-                        perms |= PROT_EXEC;
-                    }
-                    // std::cerr<<"--parsed: "<<std::hex<<start<<" "<<stop<<" "<<r<<w<<x<<std::endl;
-                    return perms;
-                }
-                stream.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-            }
-            throw std::runtime_error("Failed to find mapping with page in /proc/self/maps");
-        }
-        #endif
-        void mprotect_page(void* page, int page_size, int protections) {
-            if(mprotect(page, page_size, protections) != 0) {
-                throw std::runtime_error(microfmt::format("mprotect call failed: {}", strerror(errno)));
-            }
-        }
-        int mprotect_page_and_return_old_protections(void* page, int page_size, int protections) {
-            auto old_protections = get_page_protections(page);
-            mprotect_page(page, page_size, protections);
-            return old_protections;
-        }
-        void* allocate_page(int page_size) {
-            auto page = mmap(nullptr, page_size, memory_readwrite, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
-            if(page == MAP_FAILED) {
-                throw std::runtime_error(microfmt::format("mmap call failed: {}", strerror(errno)));
-            }
-            return page;
-        }
-        #endif
-
-        void perform_typeinfo_surgery(const std::type_info& info, do_catch_fn* do_catch_function) {
-            if(vtable_size == 0) { // set to zero if we don't know what standard library we're working with
-                return;
-            }
-            void* type_info_pointer = const_cast<void*>(static_cast<const void*>(&info));
-            void* type_info_vtable_pointer = *static_cast<void**>(type_info_pointer);
-            // the type info vtable pointer points to two pointers inside the vtable, adjust it back
-            type_info_vtable_pointer = static_cast<void*>(static_cast<void**>(type_info_vtable_pointer) - 2);
-
-            // for libstdc++ the class type info vtable looks like
-            // 0x7ffff7f89d18 <_ZTVN10__cxxabiv117__class_type_infoE>:    0x0000000000000000  0x00007ffff7f89d00
-            //                                                            [offset           ][typeinfo pointer ]
-            // 0x7ffff7f89d28 <_ZTVN10__cxxabiv117__class_type_infoE+16>: 0x00007ffff7dd65a0  0x00007ffff7dd65c0
-            //                                                            [base destructor  ][deleting dtor    ]
-            // 0x7ffff7f89d38 <_ZTVN10__cxxabiv117__class_type_infoE+32>: 0x00007ffff7dd8f10  0x00007ffff7dd8f10
-            //                                                            [__is_pointer_p   ][__is_function_p  ]
-            // 0x7ffff7f89d48 <_ZTVN10__cxxabiv117__class_type_infoE+48>: 0x00007ffff7dd6640  0x00007ffff7dd6500
-            //                                                            [__do_catch       ][__do_upcast      ]
-            // 0x7ffff7f89d58 <_ZTVN10__cxxabiv117__class_type_infoE+64>: 0x00007ffff7dd65e0  0x00007ffff7dd66d0
-            //                                                            [__do_upcast      ][__do_dyncast     ]
-            // 0x7ffff7f89d68 <_ZTVN10__cxxabiv117__class_type_infoE+80>: 0x00007ffff7dd6580  0x00007ffff7f8abe8
-            //                                                            [__do_find_public_src][other         ]
-            // In libc++ the layout is
-            //  [offset           ][typeinfo pointer ]
-            //  [base destructor  ][deleting dtor    ]
-            //  [noop1            ][noop2            ]
-            //  [can_catch        ][search_above_dst ]
-            //  [search_below_dst ][has_unambiguous_public_base]
-            // Relevant documentation/implementation:
-            //  https://itanium-cxx-abi.github.io/cxx-abi/abi.html
-            //  libstdc++
-            //   https://github.com/gcc-mirror/gcc/blob/b13e34699c7d27e561fcfe1b66ced1e50e69976f/libstdc%252B%252B-v3/libsupc%252B%252B/typeinfo
-            //   https://github.com/gcc-mirror/gcc/blob/b13e34699c7d27e561fcfe1b66ced1e50e69976f/libstdc%252B%252B-v3/libsupc%252B%252B/class_type_info.cc
-            //  libc++
-            //   https://github.com/llvm/llvm-project/blob/648f4d0658ab00cf1e95330c8811aaea9481a274/libcxx/include/typeinfo
-            //   https://github.com/llvm/llvm-project/blob/648f4d0658ab00cf1e95330c8811aaea9481a274/libcxxabi/src/private_typeinfo.h
-
-            // shouldn't be anything other than 4096 but out of an abundance of caution
-            auto page_size = get_page_size();
-            if(page_size <= 0 && (page_size & (page_size - 1)) != 0) {
-                throw std::runtime_error(
-                    microfmt::format("getpagesize() is not a power of 2 greater than zero (was {})", page_size)
-                );
-            }
-
-            // allocate a page for the new vtable so it can be made read-only later
-            // the OS cleans this up, no cleanup done here for it
-            void* new_vtable_page = allocate_page(page_size);
-            // make our own copy of the vtable
-            memcpy(new_vtable_page, type_info_vtable_pointer, vtable_size * sizeof(void*));
-            // ninja in the custom __do_catch interceptor
-            auto new_vtable = static_cast<void**>(new_vtable_page);
-            new_vtable[6] = reinterpret_cast<void*>(do_catch_function);
-            // make the page read-only
-            mprotect_page(new_vtable_page, page_size, memory_readonly);
-
-            // make the vtable pointer for unwind_interceptor's type_info point to the new vtable
-            auto type_info_addr = reinterpret_cast<uintptr_t>(type_info_pointer);
-            auto page_addr = type_info_addr & ~(page_size - 1);
-            // make sure the memory we're going to set is within the page
-            if(type_info_addr - page_addr + sizeof(void*) > static_cast<unsigned>(page_size)) {
-                throw std::runtime_error("pointer crosses page boundaries");
-            }
-            auto old_protections = mprotect_page_and_return_old_protections(
-                reinterpret_cast<void*>(page_addr),
-                page_size,
-                memory_readwrite
-            );
-            *static_cast<void**>(type_info_pointer) = static_cast<void*>(new_vtable + 2);
-            mprotect_page(reinterpret_cast<void*>(page_addr), page_size, old_protections);
-        }
-
-        void do_prepare_unwind_interceptor(char(*intercept_unwind_handler)(std::size_t)) {
-            static bool did_prepare = false;
-            if(!did_prepare) {
-                cpptrace::detail::intercept_unwind_handler = intercept_unwind_handler;
-                try {
-                    perform_typeinfo_surgery(typeid(cpptrace::detail::unwind_interceptor), intercept_unwind);
-                    perform_typeinfo_surgery(
-                        typeid(cpptrace::detail::unconditional_unwind_interceptor),
-                        unconditional_exception_unwind_interceptor
-                    );
-                } catch(std::exception& e) {
-                    std::fprintf(
-                        stderr,
-                        "Cpptrace: Exception occurred while preparing from_current support: %s\n",
-                        e.what()
-                    );
-                } catch(...) {
-                    std::fprintf(stderr, "Cpptrace: Unknown exception occurred while preparing from_current support\n");
-                }
-                did_prepare = true;
-            }
-        }
-        #endif
-    }
-
-    const raw_trace& raw_trace_from_current_exception() {
-        return detail::current_exception_trace.get_raw_trace();
-    }
-
-    const stacktrace& from_current_exception() {
-        return detail::current_exception_trace.get_resolved_trace();
-    }
+CPPTRACE_FORCE_NO_INLINE void collect_current_trace(std::size_t skip) {
+  current_exception_trace =
+      lazy_trace_holder(cpptrace::generate_raw_trace(skip + 1));
 }
+
+#ifndef _MSC_VER
+// set only once by do_prepare_unwind_interceptor
+char (*intercept_unwind_handler)(std::size_t) = nullptr;
+
+CPPTRACE_FORCE_NO_INLINE
+bool intercept_unwind(const std::type_info *, const std::type_info *, void **,
+                      unsigned) {
+  if (intercept_unwind_handler) {
+    intercept_unwind_handler(1);
+  }
+  return false;
+}
+
+CPPTRACE_FORCE_NO_INLINE
+bool unconditional_exception_unwind_interceptor(const std::type_info *,
+                                                const std::type_info *, void **,
+                                                unsigned) {
+  collect_current_trace(1);
+  return false;
+}
+
+using do_catch_fn = decltype(intercept_unwind);
+
+unwind_interceptor::~unwind_interceptor() = default;
+unconditional_unwind_interceptor::~unconditional_unwind_interceptor() = default;
+
+#if IS_LIBSTDCXX
+constexpr size_t vtable_size = 11;
+#elif IS_LIBCXX
+constexpr size_t vtable_size = 10;
+#else
+#warning                                                                       \
+    "Cpptrace from_current: Unrecognized C++ standard library, from_current() won't be supported"
+constexpr size_t vtable_size = 0;
+#endif
+
+#if IS_WINDOWS
+int get_page_size() {
+  SYSTEM_INFO info;
+  GetSystemInfo(&info);
+  return info.dwPageSize;
+}
+constexpr auto memory_readonly = PAGE_READONLY;
+constexpr auto memory_readwrite = PAGE_READWRITE;
+int mprotect_page_and_return_old_protections(void *page, int page_size,
+                                             int protections) {
+  DWORD old_protections;
+  if (!VirtualProtect(page, page_size, protections, &old_protections)) {
+    throw std::runtime_error(microfmt::format(
+        "VirtualProtect call failed: {}",
+        std::system_error(GetLastError(), std::system_category()).what()));
+  }
+  return old_protections;
+}
+void mprotect_page(void *page, int page_size, int protections) {
+  mprotect_page_and_return_old_protections(page, page_size, protections);
+}
+void *allocate_page(int page_size) {
+  auto page = VirtualAlloc(nullptr, page_size, MEM_COMMIT | MEM_RESERVE,
+                           memory_readwrite);
+  if (!page) {
+    throw std::runtime_error(microfmt::format(
+        "VirtualAlloc call failed: {}",
+        std::system_error(GetLastError(), std::system_category()).what()));
+  }
+  return page;
+}
+#else
+int get_page_size() { return getpagesize(); }
+constexpr auto memory_readonly = PROT_READ;
+constexpr auto memory_readwrite = PROT_READ | PROT_WRITE;
+#if IS_APPLE
+int get_page_protections(void *page) {
+  // https://stackoverflow.com/a/12627784/15675011
+  mach_vm_size_t vmsize;
+  mach_vm_address_t address = (mach_vm_address_t)page;
+  vm_region_basic_info_data_t info;
+  mach_msg_type_number_t info_count = sizeof(size_t) == 8
+                                          ? VM_REGION_BASIC_INFO_COUNT_64
+                                          : VM_REGION_BASIC_INFO_COUNT;
+  memory_object_name_t object;
+  kern_return_t status =
+      mach_vm_region(mach_task_self(), &address, &vmsize, VM_REGION_BASIC_INFO,
+                     (vm_region_info_t)&info, &info_count, &object);
+  if (status == KERN_INVALID_ADDRESS) {
+    throw std::runtime_error("vm_region failed with KERN_INVALID_ADDRESS");
+  }
+  int perms = 0;
+  if (info.protection & VM_PROT_READ) {
+    perms |= PROT_READ;
+  }
+  if (info.protection & VM_PROT_WRITE) {
+    perms |= PROT_WRITE;
+  }
+  if (info.protection & VM_PROT_EXECUTE) {
+    perms |= PROT_EXEC;
+  }
+  return perms;
+}
+#else
+int get_page_protections(void *page) {
+  auto page_addr = reinterpret_cast<uintptr_t>(page);
+  std::ifstream stream("/proc/self/maps");
+  stream >> std::hex;
+  while (!stream.eof()) {
+    uintptr_t start;
+    uintptr_t stop;
+    stream >> start;
+    stream.ignore(1); // dash
+    stream >> stop;
+    if (stream.eof()) {
+      break;
+    }
+    if (stream.fail()) {
+      throw std::runtime_error("Failure reading /proc/self/maps");
+    }
+    if (page_addr >= start && page_addr < stop) {
+      stream.ignore(1); // space
+      char r, w,
+          x; // there's a private/shared flag after these but we don't need it
+      stream >> r >> w >> x;
+      if (stream.fail() || stream.eof()) {
+        throw std::runtime_error("Failure reading /proc/self/maps");
+      }
+      int perms = 0;
+      if (r == 'r') {
+        perms |= PROT_READ;
+      }
+      if (w == 'w') {
+        perms |= PROT_WRITE;
+      }
+      if (x == 'x') {
+        perms |= PROT_EXEC;
+      }
+      // std::cerr<<"--parsed: "<<std::hex<<start<<" "<<stop<<"
+      // "<<r<<w<<x<<std::endl;
+      return perms;
+    }
+    stream.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+  }
+  throw std::runtime_error(
+      "Failed to find mapping with page in /proc/self/maps");
+}
+#endif
+void mprotect_page(void *page, int page_size, int protections) {
+  if (mprotect(page, page_size, protections) != 0) {
+    throw std::runtime_error(
+        microfmt::format("mprotect call failed: {}", strerror(errno)));
+  }
+}
+int mprotect_page_and_return_old_protections(void *page, int page_size,
+                                             int protections) {
+  auto old_protections = get_page_protections(page);
+  mprotect_page(page, page_size, protections);
+  return old_protections;
+}
+void *allocate_page(int page_size) {
+  auto page = mmap(nullptr, page_size, memory_readwrite,
+                   MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+  if (page == MAP_FAILED) {
+    throw std::runtime_error(
+        microfmt::format("mmap call failed: {}", strerror(errno)));
+  }
+  return page;
+}
+#endif
+
+void perform_typeinfo_surgery(const std::type_info &info,
+                              do_catch_fn *do_catch_function) {
+  if (vtable_size == 0) { // set to zero if we don't know what standard library
+                          // we're working with
+    return;
+  }
+  void *type_info_pointer =
+      const_cast<void *>(static_cast<const void *>(&info));
+  void *type_info_vtable_pointer = *static_cast<void **>(type_info_pointer);
+  // the type info vtable pointer points to two pointers inside the vtable,
+  // adjust it back
+  type_info_vtable_pointer =
+      static_cast<void *>(static_cast<void **>(type_info_vtable_pointer) - 2);
+
+  // for libstdc++ the class type info vtable looks like
+  // 0x7ffff7f89d18 <_ZTVN10__cxxabiv117__class_type_infoE>: 0x0000000000000000
+  // 0x00007ffff7f89d00
+  //                                                            [offset
+  //                                                            ][typeinfo
+  //                                                            pointer ]
+  // 0x7ffff7f89d28 <_ZTVN10__cxxabiv117__class_type_infoE+16>:
+  // 0x00007ffff7dd65a0  0x00007ffff7dd65c0
+  //                                                            [base destructor
+  //                                                            ][deleting dtor
+  //                                                            ]
+  // 0x7ffff7f89d38 <_ZTVN10__cxxabiv117__class_type_infoE+32>:
+  // 0x00007ffff7dd8f10  0x00007ffff7dd8f10
+  //                                                            [__is_pointer_p
+  //                                                            ][__is_function_p
+  //                                                            ]
+  // 0x7ffff7f89d48 <_ZTVN10__cxxabiv117__class_type_infoE+48>:
+  // 0x00007ffff7dd6640  0x00007ffff7dd6500
+  //                                                            [__do_catch
+  //                                                            ][__do_upcast ]
+  // 0x7ffff7f89d58 <_ZTVN10__cxxabiv117__class_type_infoE+64>:
+  // 0x00007ffff7dd65e0  0x00007ffff7dd66d0
+  //                                                            [__do_upcast
+  //                                                            ][__do_dyncast ]
+  // 0x7ffff7f89d68 <_ZTVN10__cxxabiv117__class_type_infoE+80>:
+  // 0x00007ffff7dd6580  0x00007ffff7f8abe8
+  //                                                            [__do_find_public_src][other
+  //                                                            ]
+  // In libc++ the layout is
+  //  [offset           ][typeinfo pointer ]
+  //  [base destructor  ][deleting dtor    ]
+  //  [noop1            ][noop2            ]
+  //  [can_catch        ][search_above_dst ]
+  //  [search_below_dst ][has_unambiguous_public_base]
+  // Relevant documentation/implementation:
+  //  https://itanium-cxx-abi.github.io/cxx-abi/abi.html
+  //  libstdc++
+  //   https://github.com/gcc-mirror/gcc/blob/b13e34699c7d27e561fcfe1b66ced1e50e69976f/libstdc%252B%252B-v3/libsupc%252B%252B/typeinfo
+  //   https://github.com/gcc-mirror/gcc/blob/b13e34699c7d27e561fcfe1b66ced1e50e69976f/libstdc%252B%252B-v3/libsupc%252B%252B/class_type_info.cc
+  //  libc++
+  //   https://github.com/llvm/llvm-project/blob/648f4d0658ab00cf1e95330c8811aaea9481a274/libcxx/include/typeinfo
+  //   https://github.com/llvm/llvm-project/blob/648f4d0658ab00cf1e95330c8811aaea9481a274/libcxxabi/src/private_typeinfo.h
+
+  // shouldn't be anything other than 4096 but out of an abundance of caution
+  auto page_size = get_page_size();
+  if (page_size <= 0 && (page_size & (page_size - 1)) != 0) {
+    throw std::runtime_error(microfmt::format(
+        "getpagesize() is not a power of 2 greater than zero (was {})",
+        page_size));
+  }
+
+  // allocate a page for the new vtable so it can be made read-only later
+  // the OS cleans this up, no cleanup done here for it
+  void *new_vtable_page = allocate_page(page_size);
+  // make our own copy of the vtable
+  memcpy(new_vtable_page, type_info_vtable_pointer,
+         vtable_size * sizeof(void *));
+  // ninja in the custom __do_catch interceptor
+  auto new_vtable = static_cast<void **>(new_vtable_page);
+  new_vtable[6] = reinterpret_cast<void *>(do_catch_function);
+  // make the page read-only
+  mprotect_page(new_vtable_page, page_size, memory_readonly);
+
+  // make the vtable pointer for unwind_interceptor's type_info point to the new
+  // vtable
+  auto type_info_addr = reinterpret_cast<uintptr_t>(type_info_pointer);
+  auto page_addr = type_info_addr & ~(page_size - 1);
+  // make sure the memory we're going to set is within the page
+  if (type_info_addr - page_addr + sizeof(void *) >
+      static_cast<unsigned>(page_size)) {
+    throw std::runtime_error("pointer crosses page boundaries");
+  }
+  auto old_protections = mprotect_page_and_return_old_protections(
+      reinterpret_cast<void *>(page_addr), page_size, memory_readwrite);
+  *static_cast<void **>(type_info_pointer) =
+      static_cast<void *>(new_vtable + 2);
+  mprotect_page(reinterpret_cast<void *>(page_addr), page_size,
+                old_protections);
+}
+
+void do_prepare_unwind_interceptor(
+    char (*intercept_unwind_handler)(std::size_t)) {
+  static bool did_prepare = false;
+  if (!did_prepare) {
+    cpptrace::detail::intercept_unwind_handler = intercept_unwind_handler;
+    try {
+      perform_typeinfo_surgery(typeid(cpptrace::detail::unwind_interceptor),
+                               intercept_unwind);
+      perform_typeinfo_surgery(
+          typeid(cpptrace::detail::unconditional_unwind_interceptor),
+          unconditional_exception_unwind_interceptor);
+    } catch (std::exception &e) {
+      std::fprintf(stderr,
+                   "Cpptrace: Exception occurred while preparing from_current "
+                   "support: %s\n",
+                   e.what());
+    } catch (...) {
+      std::fprintf(stderr, "Cpptrace: Unknown exception occurred while "
+                           "preparing from_current support\n");
+    }
+    did_prepare = true;
+  }
+}
+#endif
+} // namespace detail
+
+const raw_trace &raw_trace_from_current_exception() {
+  return detail::current_exception_trace.get_raw_trace();
+}
+
+const stacktrace &from_current_exception() {
+  return detail::current_exception_trace.get_resolved_trace();
+}
+} // namespace cpptrace

--- a/src/from_current.cpp
+++ b/src/from_current.cpp
@@ -9,324 +9,300 @@
 #include "utils/microfmt.hpp"
 
 #ifndef _MSC_VER
-#include <string.h>
-#if IS_WINDOWS
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#else
-#include <sys/mman.h>
-#include <unistd.h>
-#if IS_APPLE
-#include <mach/mach.h>
-#include <mach/mach_vm.h>
-#else
-#include <fstream>
-#include <ios>
-#endif
-#endif
+ #include <string.h>
+ #if IS_WINDOWS
+  #define WIN32_LEAN_AND_MEAN
+  #include <windows.h>
+ #else
+  #include <sys/mman.h>
+  #include <unistd.h>
+  #if IS_APPLE
+   #include <mach/mach.h>
+   #include <mach/mach_vm.h>
+  #else
+   #include <fstream>
+   #include <ios>
+  #endif
+ #endif
 #endif
 
 namespace cpptrace {
-namespace detail {
-thread_local lazy_trace_holder current_exception_trace;
+    namespace detail {
+        thread_local lazy_trace_holder current_exception_trace;
 
-CPPTRACE_FORCE_NO_INLINE void collect_current_trace(std::size_t skip) {
-  current_exception_trace =
-      lazy_trace_holder(cpptrace::generate_raw_trace(skip + 1));
-}
+        CPPTRACE_FORCE_NO_INLINE void collect_current_trace(std::size_t skip) {
+            current_exception_trace = lazy_trace_holder(cpptrace::generate_raw_trace(skip + 1));
+        }
 
-#ifndef _MSC_VER
-// set only once by do_prepare_unwind_interceptor
-char (*intercept_unwind_handler)(std::size_t) = nullptr;
+        #ifndef _MSC_VER
+        // set only once by do_prepare_unwind_interceptor
+        char (*intercept_unwind_handler)(std::size_t) = nullptr;
 
-CPPTRACE_FORCE_NO_INLINE
-bool intercept_unwind(const std::type_info *, const std::type_info *, void **,
-                      unsigned) {
-  if (intercept_unwind_handler) {
-    intercept_unwind_handler(1);
-  }
-  return false;
-}
+        CPPTRACE_FORCE_NO_INLINE
+        bool intercept_unwind(const std::type_info*, const std::type_info*, void**, unsigned) {
+            if(intercept_unwind_handler) {
+                intercept_unwind_handler(1);
+            }
+            return false;
+        }
 
-CPPTRACE_FORCE_NO_INLINE
-bool unconditional_exception_unwind_interceptor(const std::type_info *,
-                                                const std::type_info *, void **,
-                                                unsigned) {
-  collect_current_trace(1);
-  return false;
-}
+        CPPTRACE_FORCE_NO_INLINE
+        bool unconditional_exception_unwind_interceptor(const std::type_info*, const std::type_info*, void**, unsigned) {
+            collect_current_trace(1);
+            return false;
+        }
 
-using do_catch_fn = decltype(intercept_unwind);
+        using do_catch_fn = decltype(intercept_unwind);
 
-unwind_interceptor::~unwind_interceptor() = default;
-unconditional_unwind_interceptor::~unconditional_unwind_interceptor() = default;
+        unwind_interceptor::~unwind_interceptor() = default;
+        unconditional_unwind_interceptor::~unconditional_unwind_interceptor() = default;
 
-#if IS_LIBSTDCXX
-constexpr size_t vtable_size = 11;
-#elif IS_LIBCXX
-constexpr size_t vtable_size = 10;
-#else
-#warning                                                                       \
-    "Cpptrace from_current: Unrecognized C++ standard library, from_current() won't be supported"
-constexpr size_t vtable_size = 0;
-#endif
+        #if IS_LIBSTDCXX
+            constexpr size_t vtable_size = 11;
+        #elif IS_LIBCXX
+            constexpr size_t vtable_size = 10;
+        #else
+            #warning "Cpptrace from_current: Unrecognized C++ standard library, from_current() won't be supported"
+            constexpr size_t vtable_size = 0;
+        #endif
 
-#if IS_WINDOWS
-int get_page_size() {
-  SYSTEM_INFO info;
-  GetSystemInfo(&info);
-  return info.dwPageSize;
-}
-constexpr auto memory_readonly = PAGE_READONLY;
-constexpr auto memory_readwrite = PAGE_READWRITE;
-int mprotect_page_and_return_old_protections(void *page, int page_size,
-                                             int protections) {
-  DWORD old_protections;
-  if (!VirtualProtect(page, page_size, protections, &old_protections)) {
-    throw std::runtime_error(microfmt::format(
-        "VirtualProtect call failed: {}",
-        std::system_error(GetLastError(), std::system_category()).what()));
-  }
-  return old_protections;
-}
-void mprotect_page(void *page, int page_size, int protections) {
-  mprotect_page_and_return_old_protections(page, page_size, protections);
-}
-void *allocate_page(int page_size) {
-  auto page = VirtualAlloc(nullptr, page_size, MEM_COMMIT | MEM_RESERVE,
-                           memory_readwrite);
-  if (!page) {
-    throw std::runtime_error(microfmt::format(
-        "VirtualAlloc call failed: {}",
-        std::system_error(GetLastError(), std::system_category()).what()));
-  }
-  return page;
-}
-#else
-int get_page_size() { return getpagesize(); }
-constexpr auto memory_readonly = PROT_READ;
-constexpr auto memory_readwrite = PROT_READ | PROT_WRITE;
-#if IS_APPLE
-int get_page_protections(void *page) {
-  // https://stackoverflow.com/a/12627784/15675011
-  mach_vm_size_t vmsize;
-  mach_vm_address_t address = (mach_vm_address_t)page;
-  vm_region_basic_info_data_t info;
-  mach_msg_type_number_t info_count = sizeof(size_t) == 8
-                                          ? VM_REGION_BASIC_INFO_COUNT_64
-                                          : VM_REGION_BASIC_INFO_COUNT;
-  memory_object_name_t object;
-  kern_return_t status =
-      mach_vm_region(mach_task_self(), &address, &vmsize, VM_REGION_BASIC_INFO,
-                     (vm_region_info_t)&info, &info_count, &object);
-  if (status == KERN_INVALID_ADDRESS) {
-    throw std::runtime_error("vm_region failed with KERN_INVALID_ADDRESS");
-  }
-  int perms = 0;
-  if (info.protection & VM_PROT_READ) {
-    perms |= PROT_READ;
-  }
-  if (info.protection & VM_PROT_WRITE) {
-    perms |= PROT_WRITE;
-  }
-  if (info.protection & VM_PROT_EXECUTE) {
-    perms |= PROT_EXEC;
-  }
-  return perms;
-}
-#else
-int get_page_protections(void *page) {
-  auto page_addr = reinterpret_cast<uintptr_t>(page);
-  std::ifstream stream("/proc/self/maps");
-  stream >> std::hex;
-  while (!stream.eof()) {
-    uintptr_t start;
-    uintptr_t stop;
-    stream >> start;
-    stream.ignore(1); // dash
-    stream >> stop;
-    if (stream.eof()) {
-      break;
+        #if IS_WINDOWS
+        int get_page_size() {
+            SYSTEM_INFO info;
+            GetSystemInfo(&info);
+            return info.dwPageSize;
+        }
+        constexpr auto memory_readonly = PAGE_READONLY;
+        constexpr auto memory_readwrite = PAGE_READWRITE;
+        int mprotect_page_and_return_old_protections(void* page, int page_size, int protections) {
+            DWORD old_protections;
+            if(!VirtualProtect(page, page_size, protections, &old_protections)) {
+                throw std::runtime_error(
+                    microfmt::format(
+                        "VirtualProtect call failed: {}",
+                        std::system_error(GetLastError(), std::system_category()).what()
+                    )
+                );
+            }
+            return old_protections;
+        }
+        void mprotect_page(void* page, int page_size, int protections) {
+            mprotect_page_and_return_old_protections(page, page_size, protections);
+        }
+        void* allocate_page(int page_size) {
+            auto page = VirtualAlloc(nullptr, page_size, MEM_COMMIT | MEM_RESERVE, memory_readwrite);
+            if(!page) {
+                throw std::runtime_error(
+                    microfmt::format(
+                        "VirtualAlloc call failed: {}",
+                        std::system_error(GetLastError(), std::system_category()).what()
+                    )
+                );
+            }
+            return page;
+        }
+        #else
+        int get_page_size() {
+            return getpagesize();
+        }
+        constexpr auto memory_readonly = PROT_READ;
+        constexpr auto memory_readwrite = PROT_READ | PROT_WRITE;
+        #if IS_APPLE
+        int get_page_protections(void* page) {
+            // https://stackoverflow.com/a/12627784/15675011
+            mach_vm_size_t vmsize;
+            mach_vm_address_t address = (mach_vm_address_t)page;
+            vm_region_basic_info_data_t info;
+            mach_msg_type_number_t info_count =
+                sizeof(size_t) == 8 ? VM_REGION_BASIC_INFO_COUNT_64 : VM_REGION_BASIC_INFO_COUNT;
+            memory_object_name_t object;
+            kern_return_t status = mach_vm_region(
+                mach_task_self(),
+                &address,
+                &vmsize,
+                VM_REGION_BASIC_INFO,
+                (vm_region_info_t)&info,
+                &info_count,
+                &object
+            );
+            if(status == KERN_INVALID_ADDRESS) {
+                throw std::runtime_error("vm_region failed with KERN_INVALID_ADDRESS");
+            }
+            int perms = 0;
+            if(info.protection & VM_PROT_READ) {
+                perms |= PROT_READ;
+            }
+            if(info.protection & VM_PROT_WRITE) {
+                perms |= PROT_WRITE;
+            }
+            if(info.protection & VM_PROT_EXECUTE) {
+                perms |= PROT_EXEC;
+            }
+            return perms;
+        }
+        #else
+        int get_page_protections(void* page) {
+            auto page_addr = reinterpret_cast<uintptr_t>(page);
+            std::ifstream stream("/proc/self/maps");
+            stream>>std::hex;
+            while(!stream.eof()) {
+                uintptr_t start;
+                uintptr_t stop;
+                stream>>start;
+                stream.ignore(1); // dash
+                stream>>stop;
+                if(stream.eof()) {
+                    break;
+                }
+                if(stream.fail()) {
+                    throw std::runtime_error("Failure reading /proc/self/maps");
+                }
+                if(page_addr >= start && page_addr < stop) {
+                    stream.ignore(1); // space
+                    char r, w, x; // there's a private/shared flag after these but we don't need it
+                    stream>>r>>w>>x;
+                    if(stream.fail() || stream.eof()) {
+                        throw std::runtime_error("Failure reading /proc/self/maps");
+                    }
+                    int perms = 0;
+                    if(r == 'r') {
+                        perms |= PROT_READ;
+                    }
+                    if(w == 'w') {
+                        perms |= PROT_WRITE;
+                    }
+                    if(x == 'x') {
+                        perms |= PROT_EXEC;
+                    }
+                    // std::cerr<<"--parsed: "<<std::hex<<start<<" "<<stop<<" "<<r<<w<<x<<std::endl;
+                    return perms;
+                }
+                stream.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+            }
+            throw std::runtime_error("Failed to find mapping with page in /proc/self/maps");
+        }
+        #endif
+        void mprotect_page(void* page, int page_size, int protections) {
+            if(mprotect(page, page_size, protections) != 0) {
+                throw std::runtime_error(microfmt::format("mprotect call failed: {}", strerror(errno)));
+            }
+        }
+        int mprotect_page_and_return_old_protections(void* page, int page_size, int protections) {
+            auto old_protections = get_page_protections(page);
+            mprotect_page(page, page_size, protections);
+            return old_protections;
+        }
+        void* allocate_page(int page_size) {
+            auto page = mmap(nullptr, page_size, memory_readwrite, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+            if(page == MAP_FAILED) {
+                throw std::runtime_error(microfmt::format("mmap call failed: {}", strerror(errno)));
+            }
+            return page;
+        }
+        #endif
+
+        void perform_typeinfo_surgery(const std::type_info& info, do_catch_fn* do_catch_function) {
+            if(vtable_size == 0) { // set to zero if we don't know what standard library we're working with
+                return;
+            }
+            void* type_info_pointer = const_cast<void*>(static_cast<const void*>(&info));
+            void* type_info_vtable_pointer = *static_cast<void**>(type_info_pointer);
+            // the type info vtable pointer points to two pointers inside the vtable, adjust it back
+            type_info_vtable_pointer = static_cast<void*>(static_cast<void**>(type_info_vtable_pointer) - 2);
+
+            // for libstdc++ the class type info vtable looks like
+            // 0x7ffff7f89d18 <_ZTVN10__cxxabiv117__class_type_infoE>:    0x0000000000000000  0x00007ffff7f89d00
+            //                                                            [offset           ][typeinfo pointer ]
+            // 0x7ffff7f89d28 <_ZTVN10__cxxabiv117__class_type_infoE+16>: 0x00007ffff7dd65a0  0x00007ffff7dd65c0
+            //                                                            [base destructor  ][deleting dtor    ]
+            // 0x7ffff7f89d38 <_ZTVN10__cxxabiv117__class_type_infoE+32>: 0x00007ffff7dd8f10  0x00007ffff7dd8f10
+            //                                                            [__is_pointer_p   ][__is_function_p  ]
+            // 0x7ffff7f89d48 <_ZTVN10__cxxabiv117__class_type_infoE+48>: 0x00007ffff7dd6640  0x00007ffff7dd6500
+            //                                                            [__do_catch       ][__do_upcast      ]
+            // 0x7ffff7f89d58 <_ZTVN10__cxxabiv117__class_type_infoE+64>: 0x00007ffff7dd65e0  0x00007ffff7dd66d0
+            //                                                            [__do_upcast      ][__do_dyncast     ]
+            // 0x7ffff7f89d68 <_ZTVN10__cxxabiv117__class_type_infoE+80>: 0x00007ffff7dd6580  0x00007ffff7f8abe8
+            //                                                            [__do_find_public_src][other         ]
+            // In libc++ the layout is
+            //  [offset           ][typeinfo pointer ]
+            //  [base destructor  ][deleting dtor    ]
+            //  [noop1            ][noop2            ]
+            //  [can_catch        ][search_above_dst ]
+            //  [search_below_dst ][has_unambiguous_public_base]
+            // Relevant documentation/implementation:
+            //  https://itanium-cxx-abi.github.io/cxx-abi/abi.html
+            //  libstdc++
+            //   https://github.com/gcc-mirror/gcc/blob/b13e34699c7d27e561fcfe1b66ced1e50e69976f/libstdc%252B%252B-v3/libsupc%252B%252B/typeinfo
+            //   https://github.com/gcc-mirror/gcc/blob/b13e34699c7d27e561fcfe1b66ced1e50e69976f/libstdc%252B%252B-v3/libsupc%252B%252B/class_type_info.cc
+            //  libc++
+            //   https://github.com/llvm/llvm-project/blob/648f4d0658ab00cf1e95330c8811aaea9481a274/libcxx/include/typeinfo
+            //   https://github.com/llvm/llvm-project/blob/648f4d0658ab00cf1e95330c8811aaea9481a274/libcxxabi/src/private_typeinfo.h
+
+            // shouldn't be anything other than 4096 but out of an abundance of caution
+            auto page_size = get_page_size();
+            if(page_size <= 0 && (page_size & (page_size - 1)) != 0) {
+                throw std::runtime_error(
+                    microfmt::format("getpagesize() is not a power of 2 greater than zero (was {})", page_size)
+                );
+            }
+
+            // allocate a page for the new vtable so it can be made read-only later
+            // the OS cleans this up, no cleanup done here for it
+            void* new_vtable_page = allocate_page(page_size);
+            // make our own copy of the vtable
+            memcpy(new_vtable_page, type_info_vtable_pointer, vtable_size * sizeof(void*));
+            // ninja in the custom __do_catch interceptor
+            auto new_vtable = static_cast<void**>(new_vtable_page);
+            new_vtable[6] = reinterpret_cast<void*>(do_catch_function);
+            // make the page read-only
+            mprotect_page(new_vtable_page, page_size, memory_readonly);
+
+            // make the vtable pointer for unwind_interceptor's type_info point to the new vtable
+            auto type_info_addr = reinterpret_cast<uintptr_t>(type_info_pointer);
+            auto page_addr = type_info_addr & ~(page_size - 1);
+            // make sure the memory we're going to set is within the page
+            if(type_info_addr - page_addr + sizeof(void*) > static_cast<unsigned>(page_size)) {
+                throw std::runtime_error("pointer crosses page boundaries");
+            }
+            auto old_protections = mprotect_page_and_return_old_protections(
+                reinterpret_cast<void*>(page_addr),
+                page_size,
+                memory_readwrite
+            );
+            *static_cast<void**>(type_info_pointer) = static_cast<void*>(new_vtable + 2);
+            mprotect_page(reinterpret_cast<void*>(page_addr), page_size, old_protections);
+        }
+
+        void do_prepare_unwind_interceptor(char(*intercept_unwind_handler)(std::size_t)) {
+            static bool did_prepare = false;
+            if(!did_prepare) {
+                cpptrace::detail::intercept_unwind_handler = intercept_unwind_handler;
+                try {
+                    perform_typeinfo_surgery(typeid(cpptrace::detail::unwind_interceptor), intercept_unwind);
+                    perform_typeinfo_surgery(
+                        typeid(cpptrace::detail::unconditional_unwind_interceptor),
+                        unconditional_exception_unwind_interceptor
+                    );
+                } catch(std::exception& e) {
+                    std::fprintf(
+                        stderr,
+                        "Cpptrace: Exception occurred while preparing from_current support: %s\n",
+                        e.what()
+                    );
+                } catch(...) {
+                    std::fprintf(stderr, "Cpptrace: Unknown exception occurred while preparing from_current support\n");
+                }
+                did_prepare = true;
+            }
+        }
+        #endif
     }
-    if (stream.fail()) {
-      throw std::runtime_error("Failure reading /proc/self/maps");
+
+    const raw_trace& raw_trace_from_current_exception() {
+        return detail::current_exception_trace.get_raw_trace();
     }
-    if (page_addr >= start && page_addr < stop) {
-      stream.ignore(1); // space
-      char r, w,
-          x; // there's a private/shared flag after these but we don't need it
-      stream >> r >> w >> x;
-      if (stream.fail() || stream.eof()) {
-        throw std::runtime_error("Failure reading /proc/self/maps");
-      }
-      int perms = 0;
-      if (r == 'r') {
-        perms |= PROT_READ;
-      }
-      if (w == 'w') {
-        perms |= PROT_WRITE;
-      }
-      if (x == 'x') {
-        perms |= PROT_EXEC;
-      }
-      // std::cerr<<"--parsed: "<<std::hex<<start<<" "<<stop<<"
-      // "<<r<<w<<x<<std::endl;
-      return perms;
+
+    const stacktrace& from_current_exception() {
+        return detail::current_exception_trace.get_resolved_trace();
     }
-    stream.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-  }
-  throw std::runtime_error(
-      "Failed to find mapping with page in /proc/self/maps");
 }
-#endif
-void mprotect_page(void *page, int page_size, int protections) {
-  if (mprotect(page, page_size, protections) != 0) {
-    throw std::runtime_error(
-        microfmt::format("mprotect call failed: {}", strerror(errno)));
-  }
-}
-int mprotect_page_and_return_old_protections(void *page, int page_size,
-                                             int protections) {
-  auto old_protections = get_page_protections(page);
-  mprotect_page(page, page_size, protections);
-  return old_protections;
-}
-void *allocate_page(int page_size) {
-  auto page = mmap(nullptr, page_size, memory_readwrite,
-                   MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
-  if (page == MAP_FAILED) {
-    throw std::runtime_error(
-        microfmt::format("mmap call failed: {}", strerror(errno)));
-  }
-  return page;
-}
-#endif
-
-void perform_typeinfo_surgery(const std::type_info &info,
-                              do_catch_fn *do_catch_function) {
-  if (vtable_size == 0) { // set to zero if we don't know what standard library
-                          // we're working with
-    return;
-  }
-  void *type_info_pointer =
-      const_cast<void *>(static_cast<const void *>(&info));
-  void *type_info_vtable_pointer = *static_cast<void **>(type_info_pointer);
-  // the type info vtable pointer points to two pointers inside the vtable,
-  // adjust it back
-  type_info_vtable_pointer =
-      static_cast<void *>(static_cast<void **>(type_info_vtable_pointer) - 2);
-
-  // for libstdc++ the class type info vtable looks like
-  // 0x7ffff7f89d18 <_ZTVN10__cxxabiv117__class_type_infoE>: 0x0000000000000000
-  // 0x00007ffff7f89d00
-  //                                                            [offset
-  //                                                            ][typeinfo
-  //                                                            pointer ]
-  // 0x7ffff7f89d28 <_ZTVN10__cxxabiv117__class_type_infoE+16>:
-  // 0x00007ffff7dd65a0  0x00007ffff7dd65c0
-  //                                                            [base destructor
-  //                                                            ][deleting dtor
-  //                                                            ]
-  // 0x7ffff7f89d38 <_ZTVN10__cxxabiv117__class_type_infoE+32>:
-  // 0x00007ffff7dd8f10  0x00007ffff7dd8f10
-  //                                                            [__is_pointer_p
-  //                                                            ][__is_function_p
-  //                                                            ]
-  // 0x7ffff7f89d48 <_ZTVN10__cxxabiv117__class_type_infoE+48>:
-  // 0x00007ffff7dd6640  0x00007ffff7dd6500
-  //                                                            [__do_catch
-  //                                                            ][__do_upcast ]
-  // 0x7ffff7f89d58 <_ZTVN10__cxxabiv117__class_type_infoE+64>:
-  // 0x00007ffff7dd65e0  0x00007ffff7dd66d0
-  //                                                            [__do_upcast
-  //                                                            ][__do_dyncast ]
-  // 0x7ffff7f89d68 <_ZTVN10__cxxabiv117__class_type_infoE+80>:
-  // 0x00007ffff7dd6580  0x00007ffff7f8abe8
-  //                                                            [__do_find_public_src][other
-  //                                                            ]
-  // In libc++ the layout is
-  //  [offset           ][typeinfo pointer ]
-  //  [base destructor  ][deleting dtor    ]
-  //  [noop1            ][noop2            ]
-  //  [can_catch        ][search_above_dst ]
-  //  [search_below_dst ][has_unambiguous_public_base]
-  // Relevant documentation/implementation:
-  //  https://itanium-cxx-abi.github.io/cxx-abi/abi.html
-  //  libstdc++
-  //   https://github.com/gcc-mirror/gcc/blob/b13e34699c7d27e561fcfe1b66ced1e50e69976f/libstdc%252B%252B-v3/libsupc%252B%252B/typeinfo
-  //   https://github.com/gcc-mirror/gcc/blob/b13e34699c7d27e561fcfe1b66ced1e50e69976f/libstdc%252B%252B-v3/libsupc%252B%252B/class_type_info.cc
-  //  libc++
-  //   https://github.com/llvm/llvm-project/blob/648f4d0658ab00cf1e95330c8811aaea9481a274/libcxx/include/typeinfo
-  //   https://github.com/llvm/llvm-project/blob/648f4d0658ab00cf1e95330c8811aaea9481a274/libcxxabi/src/private_typeinfo.h
-
-  // shouldn't be anything other than 4096 but out of an abundance of caution
-  auto page_size = get_page_size();
-  if (page_size <= 0 && (page_size & (page_size - 1)) != 0) {
-    throw std::runtime_error(microfmt::format(
-        "getpagesize() is not a power of 2 greater than zero (was {})",
-        page_size));
-  }
-
-  // allocate a page for the new vtable so it can be made read-only later
-  // the OS cleans this up, no cleanup done here for it
-  void *new_vtable_page = allocate_page(page_size);
-  // make our own copy of the vtable
-  memcpy(new_vtable_page, type_info_vtable_pointer,
-         vtable_size * sizeof(void *));
-  // ninja in the custom __do_catch interceptor
-  auto new_vtable = static_cast<void **>(new_vtable_page);
-  new_vtable[6] = reinterpret_cast<void *>(do_catch_function);
-  // make the page read-only
-  mprotect_page(new_vtable_page, page_size, memory_readonly);
-
-  // make the vtable pointer for unwind_interceptor's type_info point to the new
-  // vtable
-  auto type_info_addr = reinterpret_cast<uintptr_t>(type_info_pointer);
-  auto page_addr = type_info_addr & ~(page_size - 1);
-  // make sure the memory we're going to set is within the page
-  if (type_info_addr - page_addr + sizeof(void *) >
-      static_cast<unsigned>(page_size)) {
-    throw std::runtime_error("pointer crosses page boundaries");
-  }
-  auto old_protections = mprotect_page_and_return_old_protections(
-      reinterpret_cast<void *>(page_addr), page_size, memory_readwrite);
-  *static_cast<void **>(type_info_pointer) =
-      static_cast<void *>(new_vtable + 2);
-  mprotect_page(reinterpret_cast<void *>(page_addr), page_size,
-                old_protections);
-}
-
-void do_prepare_unwind_interceptor(
-    char (*intercept_unwind_handler)(std::size_t)) {
-  static bool did_prepare = false;
-  if (!did_prepare) {
-    cpptrace::detail::intercept_unwind_handler = intercept_unwind_handler;
-    try {
-      perform_typeinfo_surgery(typeid(cpptrace::detail::unwind_interceptor),
-                               intercept_unwind);
-      perform_typeinfo_surgery(
-          typeid(cpptrace::detail::unconditional_unwind_interceptor),
-          unconditional_exception_unwind_interceptor);
-    } catch (std::exception &e) {
-      std::fprintf(stderr,
-                   "Cpptrace: Exception occurred while preparing from_current "
-                   "support: %s\n",
-                   e.what());
-    } catch (...) {
-      std::fprintf(stderr, "Cpptrace: Unknown exception occurred while "
-                           "preparing from_current support\n");
-    }
-    did_prepare = true;
-  }
-}
-#endif
-} // namespace detail
-
-const raw_trace &raw_trace_from_current_exception() {
-  return detail::current_exception_trace.get_raw_trace();
-}
-
-const stacktrace &from_current_exception() {
-  return detail::current_exception_trace.get_resolved_trace();
-}
-} // namespace cpptrace

--- a/src/platform/dbghelp_syminit_manager.cpp
+++ b/src/platform/dbghelp_syminit_manager.cpp
@@ -1,3 +1,6 @@
+#include "platform/platform.hpp"
+
+#if IS_WINDOWS
 
 #include "platform/dbghelp_syminit_manager.hpp"
 
@@ -38,3 +41,5 @@ namespace detail {
 
 }
 }
+
+#endif

--- a/src/platform/dbghelp_syminit_manager.cpp
+++ b/src/platform/dbghelp_syminit_manager.cpp
@@ -1,0 +1,40 @@
+
+#include "platform/dbghelp_syminit_manager.hpp"
+
+#include "utils/error.hpp"
+#include "utils/microfmt.hpp"
+
+#include <unordered_set>
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <dbghelp.h>
+
+namespace cpptrace {
+namespace detail {
+
+    dbghelp_syminit_manager::~dbghelp_syminit_manager() {
+        for(auto handle : set) {
+            if(!SymCleanup(handle)) {
+                ASSERT(false, microfmt::format("Cpptrace SymCleanup failed with code {}\n", GetLastError()).c_str());
+            }
+        }
+    }
+
+    void dbghelp_syminit_manager::init(HANDLE proc) {
+        if(set.count(proc) == 0) {
+            if(!SymInitialize(proc, NULL, TRUE)) {
+                throw internal_error("SymInitialize failed {}", GetLastError());
+            }
+            set.insert(proc);
+        }
+    }
+
+    // Thread-safety: Must only be called from symbols_with_dbghelp while the dbghelp_lock lock is held
+    dbghelp_syminit_manager& get_syminit_manager() {
+        static dbghelp_syminit_manager syminit_manager;
+        return syminit_manager;
+    }
+
+}
+}

--- a/src/platform/dbghelp_syminit_manager.hpp
+++ b/src/platform/dbghelp_syminit_manager.hpp
@@ -6,6 +6,8 @@
 namespace cpptrace {
 namespace detail {
     struct dbghelp_syminit_manager {
+        // The set below contains Windows `HANDLE` objects, `void*` is used to avoid 
+        // including the (expensive) Windows header here
         std::unordered_set<void*> set;
 
         ~dbghelp_syminit_manager();

--- a/src/platform/dbghelp_syminit_manager.hpp
+++ b/src/platform/dbghelp_syminit_manager.hpp
@@ -1,42 +1,19 @@
 #ifndef DBGHELP_SYMINIT_MANAGER_HPP
 #define DBGHELP_SYMINIT_MANAGER_HPP
 
-#include "utils/common.hpp"
-#include "utils/utils.hpp"
-
 #include <unordered_set>
-
-#include <windows.h>
-#include <dbghelp.h>
 
 namespace cpptrace {
 namespace detail {
     struct dbghelp_syminit_manager {
-        std::unordered_set<HANDLE> set;
+        std::unordered_set<void*> set;
 
-        ~dbghelp_syminit_manager() {
-            for(auto handle : set) {
-                if(!SymCleanup(handle)) {
-                    ASSERT(false, microfmt::format("Cpptrace SymCleanup failed with code {}\n", GetLastError()).c_str());
-                }
-            }
-        }
-
-        void init(HANDLE proc) {
-            if(set.count(proc) == 0) {
-                if(!SymInitialize(proc, NULL, TRUE)) {
-                    throw internal_error("SymInitialize failed {}", GetLastError());
-                }
-                set.insert(proc);
-            }
-        }
+        ~dbghelp_syminit_manager();
+        void init(void* proc);
     };
 
     // Thread-safety: Must only be called from symbols_with_dbghelp while the dbghelp_lock lock is held
-    inline dbghelp_syminit_manager& get_syminit_manager() {
-        static dbghelp_syminit_manager syminit_manager;
-        return syminit_manager;
-    }
+    dbghelp_syminit_manager& get_syminit_manager();
 }
 }
 

--- a/src/platform/path.hpp
+++ b/src/platform/path.hpp
@@ -1,10 +1,13 @@
 #ifndef PATH_HPP
 #define PATH_HPP
 
-#include "utils/common.hpp"
 #include "platform/platform.hpp"
 
+#include <string>
+#include <cctype>
+
 #if IS_WINDOWS
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
 

--- a/src/platform/program_name.hpp
+++ b/src/platform/program_name.hpp
@@ -7,6 +7,7 @@
 #include "platform/platform.hpp"
 
 #if IS_WINDOWS
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 #define CPPTRACE_MAX_PATH MAX_PATH

--- a/src/snippets/snippet.cpp
+++ b/src/snippets/snippet.cpp
@@ -9,6 +9,7 @@
 #include <iostream>
 
 #include "utils/common.hpp"
+#include "utils/microfmt.hpp"
 #include "utils/utils.hpp"
 
 namespace cpptrace {

--- a/src/symbols/dwarf/dwarf.hpp
+++ b/src/symbols/dwarf/dwarf.hpp
@@ -3,10 +3,10 @@
 
 #include <cpptrace/cpptrace.hpp>
 #include "utils/error.hpp"
+#include "utils/microfmt.hpp"
 #include "utils/utils.hpp"
 
 #include <functional>
-#include <stdexcept>
 #include <type_traits>
 
 #ifdef CPPTRACE_USE_NESTED_LIBDWARF_HEADER_PATH

--- a/src/symbols/dwarf/dwarf_resolver.cpp
+++ b/src/symbols/dwarf/dwarf_resolver.cpp
@@ -10,15 +10,16 @@
 #include "utils/utils.hpp"
 #include "platform/path.hpp"
 #include "platform/program_name.hpp" // For CPPTRACE_MAX_PATH
+
+#if IS_APPLE
 #include "binary/mach-o.hpp"
+#endif
 
 #include <algorithm>
 #include <cstdint>
 #include <cstdio>
 #include <functional>
-#include <iterator>
 #include <memory>
-#include <stdexcept>
 #include <string>
 #include <type_traits>
 #include <unordered_map>

--- a/src/symbols/dwarf/resolver.hpp
+++ b/src/symbols/dwarf/resolver.hpp
@@ -3,7 +3,7 @@
 
 #include <cpptrace/cpptrace.hpp>
 #include "symbols/symbols.hpp"
-#include "utils/common.hpp"
+#include "platform/platform.hpp"
 
 #include <memory>
 

--- a/src/symbols/symbols.hpp
+++ b/src/symbols/symbols.hpp
@@ -3,8 +3,10 @@
 
 #include <cpptrace/cpptrace.hpp>
 
-#include <vector>
+#include <string>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 namespace cpptrace {
 namespace detail {

--- a/src/symbols/symbols.hpp
+++ b/src/symbols/symbols.hpp
@@ -3,6 +3,7 @@
 
 #include <cpptrace/cpptrace.hpp>
 
+#include <functional>
 #include <string>
 #include <unordered_map>
 #include <utility>

--- a/src/symbols/symbols.hpp
+++ b/src/symbols/symbols.hpp
@@ -3,11 +3,8 @@
 
 #include <cpptrace/cpptrace.hpp>
 
-#include <memory>
 #include <vector>
 #include <unordered_map>
-
-#include "binary/object.hpp"
 
 namespace cpptrace {
 namespace detail {

--- a/src/symbols/symbols_core.cpp
+++ b/src/symbols/symbols_core.cpp
@@ -3,7 +3,7 @@
 #include <vector>
 #include <unordered_map>
 
-#include "utils/common.hpp"
+#include "utils/error.hpp"
 #include "binary/object.hpp"
 
 namespace cpptrace {

--- a/src/symbols/symbols_core.cpp
+++ b/src/symbols/symbols_core.cpp
@@ -1,6 +1,6 @@
-#include "symbols/symbols.hpp"
-
 #include <cpptrace/cpptrace.hpp>
+
+#include "symbols/symbols.hpp"
 
 #include <vector>
 #include <unordered_map>

--- a/src/symbols/symbols_core.cpp
+++ b/src/symbols/symbols_core.cpp
@@ -1,5 +1,7 @@
 #include "symbols/symbols.hpp"
 
+#include <cpptrace/cpptrace.hpp>
+
 #include <vector>
 #include <unordered_map>
 

--- a/src/symbols/symbols_with_addr2line.cpp
+++ b/src/symbols/symbols_with_addr2line.cpp
@@ -3,6 +3,7 @@
 #include <cpptrace/cpptrace.hpp>
 #include "symbols/symbols.hpp"
 #include "utils/common.hpp"
+#include "utils/microfmt.hpp"
 #include "utils/utils.hpp"
 
 #include <cstdint>

--- a/src/symbols/symbols_with_dbghelp.cpp
+++ b/src/symbols/symbols_with_dbghelp.cpp
@@ -3,14 +3,16 @@
 #include <cpptrace/cpptrace.hpp>
 #include "symbols/symbols.hpp"
 #include "platform/dbghelp_syminit_manager.hpp"
+#include "binary/object.hpp"
+#include "utils/common.hpp"
+#include "utils/error.hpp"
 
-#include <memory>
 #include <mutex>
 #include <regex>
-#include <stdexcept>
 #include <system_error>
 #include <vector>
 
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <dbghelp.h>
 

--- a/src/symbols/symbols_with_dl.cpp
+++ b/src/symbols/symbols_with_dl.cpp
@@ -2,6 +2,7 @@
 
 #include <cpptrace/cpptrace.hpp>
 #include "symbols/symbols.hpp"
+#include "binary/module_base.hpp"
 
 #include <cstdint>
 #include <memory>

--- a/src/symbols/symbols_with_libbacktrace.cpp
+++ b/src/symbols/symbols_with_libbacktrace.cpp
@@ -3,6 +3,8 @@
 #include <cpptrace/cpptrace.hpp>
 #include "symbols/symbols.hpp"
 #include "platform/program_name.hpp"
+#include "utils/error.hpp"
+#include "utils/common.hpp"
 
 #include <cstdint>
 #include <cstdio>

--- a/src/symbols/symbols_with_libdwarf.cpp
+++ b/src/symbols/symbols_with_libdwarf.cpp
@@ -5,7 +5,6 @@
 #include <cpptrace/cpptrace.hpp>
 #include "dwarf/resolver.hpp"
 #include "utils/common.hpp"
-#include "utils/error.hpp"
 #include "utils/utils.hpp"
 
 #include <cstdint>
@@ -15,8 +14,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include <iostream>
-#include <iomanip>
 
 namespace cpptrace {
 namespace detail {

--- a/src/symbols/symbols_with_nothing.cpp
+++ b/src/symbols/symbols_with_nothing.cpp
@@ -2,6 +2,7 @@
 
 #include <cpptrace/cpptrace.hpp>
 #include "symbols/symbols.hpp"
+#include "utils/common.hpp"
 
 #include <vector>
 

--- a/src/unwind/unwind.hpp
+++ b/src/unwind/unwind.hpp
@@ -1,7 +1,7 @@
 #ifndef UNWIND_HPP
 #define UNWIND_HPP
 
-#include "cpptrace/cpptrace.hpp"
+#include <cpptrace/cpptrace.hpp>
 
 #include <cstddef>
 #include <vector>

--- a/src/unwind/unwind.hpp
+++ b/src/unwind/unwind.hpp
@@ -1,8 +1,7 @@
 #ifndef UNWIND_HPP
 #define UNWIND_HPP
 
-#include "utils/common.hpp"
-#include "utils/utils.hpp"
+#include "cpptrace/cpptrace.hpp"
 
 #include <cstddef>
 #include <vector>

--- a/src/unwind/unwind_with_dbghelp.cpp
+++ b/src/unwind/unwind_with_dbghelp.cpp
@@ -6,10 +6,9 @@
 #include "utils/utils.hpp"
 #include "platform/dbghelp_syminit_manager.hpp"
 
-#include <algorithm>
-#include <cstdint>
 #include <vector>
 #include <mutex>
+#include <cstddef>
 
 #include <windows.h>
 #include <dbghelp.h>

--- a/src/unwind/unwind_with_winapi.cpp
+++ b/src/unwind/unwind_with_winapi.cpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <vector>
 
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 // Fucking windows headers

--- a/src/utils/common.hpp
+++ b/src/utils/common.hpp
@@ -1,13 +1,11 @@
 #ifndef COMMON_HPP
 #define COMMON_HPP
 
-#include <cstdio>
-#include <stdexcept>
-#include <string>
-
 #include <cpptrace/cpptrace.hpp>
 
 #include "platform/platform.hpp"
+
+#include <cstdint>
 
 #define ESC     "\033["
 #define RESET   ESC "0m"
@@ -31,8 +29,8 @@ namespace detail {
     static const stacktrace_frame null_frame {
         0,
         0,
-        nullable<uint32_t>::null(),
-        nullable<uint32_t>::null(),
+        nullable<std::uint32_t>::null(),
+        nullable<std::uint32_t>::null(),
         "",
         "",
         false

--- a/src/utils/error.hpp
+++ b/src/utils/error.hpp
@@ -2,11 +2,10 @@
 #define ERROR_HPP
 
 #include <exception>
-#include <stdexcept>
 #include <string>
 #include <utility>
 
-#include "utils/common.hpp"
+#include "platform/platform.hpp"
 #include "utils/microfmt.hpp"
 
 #if IS_MSVC

--- a/src/utils/microfmt.cpp
+++ b/src/utils/microfmt.cpp
@@ -1,0 +1,14 @@
+#include "utils/microfmt.hpp"
+
+#include <iostream>
+
+namespace cpptrace {
+namespace detail {
+
+    std::ostream& get_cout()
+    {
+        return std::cout;
+    }
+
+}
+}

--- a/src/utils/microfmt.cpp
+++ b/src/utils/microfmt.cpp
@@ -5,8 +5,7 @@
 namespace cpptrace {
 namespace detail {
 
-    std::ostream& get_cout()
-    {
+    std::ostream& get_cout() {
         return std::cout;
     }
 

--- a/src/utils/microfmt.hpp
+++ b/src/utils/microfmt.hpp
@@ -1,11 +1,10 @@
 #ifndef MICROFMT_HPP
 #define MICROFMT_HPP
 
-#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <cstring>
-#include <iostream>
+#include <iosfwd>
 #include <string>
 #if ((defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || __cplusplus >= 201703L)
  #include <string_view>
@@ -285,9 +284,11 @@ namespace microfmt {
         return detail::format<1>(fmt, fmt + std::strlen(fmt), {detail::format_value(1)});
     }
 
+    std::ostream& get_cout();
+
     template<typename S, typename... Args>
     void print(const S& fmt, Args&&... args) {
-        std::cout<<format(fmt, args...);
+        get_cout()<<format(fmt, args...);
     }
 
     template<typename S, typename... Args>

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -1,0 +1,59 @@
+#include "utils/utils.hpp"
+
+#if IS_WINDOWS
+ #include <io.h>
+ #define WIN32_LEAN_AND_MEAN
+ #include <windows.h>
+#else
+ #include <sys/stat.h>
+ #include <unistd.h>
+#endif
+
+namespace cpptrace {
+namespace detail {
+
+    bool isatty(int fd) {
+        #if IS_WINDOWS
+         return _isatty(fd);
+        #else
+         return ::isatty(fd);
+        #endif
+    }
+
+    int fileno(std::FILE* stream) {
+        #if IS_WINDOWS
+         return _fileno(stream);
+        #else
+         return ::fileno(stream);
+        #endif
+    }
+
+    void enable_virtual_terminal_processing_if_needed() noexcept
+    {
+        // enable colors / ansi processing if necessary
+        #if IS_WINDOWS
+         // https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences#example-of-enabling-virtual-terminal-processing
+         #ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+          constexpr DWORD ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x4;
+         #endif
+         HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+         DWORD dwMode = 0;
+         if(hOut == INVALID_HANDLE_VALUE) return;
+         if(!GetConsoleMode(hOut, &dwMode)) return;
+         if(dwMode != (dwMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING))
+         if(!SetConsoleMode(hOut, dwMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING)) return;
+        #endif
+    }
+
+    bool directory_exists(const std::string& path) {
+        #if IS_WINDOWS
+         DWORD dwAttrib = GetFileAttributesA(path.c_str());
+         return dwAttrib != INVALID_FILE_ATTRIBUTES && (dwAttrib & FILE_ATTRIBUTE_DIRECTORY);
+        #else
+         struct stat sb;
+         return stat(path.c_str(), &sb) == 0 && S_ISDIR(sb.st_mode);
+        #endif
+    }
+
+}
+}

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -28,8 +28,7 @@ namespace detail {
         #endif
     }
 
-    void enable_virtual_terminal_processing_if_needed() noexcept
-    {
+    void enable_virtual_terminal_processing_if_needed() noexcept {
         // enable colors / ansi processing if necessary
         #if IS_WINDOWS
          // https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences#example-of-enabling-virtual-terminal-processing

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -8,6 +8,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <memory>
+#include <new>
 #include <string>
 #include <type_traits>
 #include <utility>

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -7,12 +7,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <exception>
-#include <ios>
 #include <memory>
-#include <new>
-#include <sstream>
-#include <stdexcept>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -20,33 +15,13 @@
 
 #include "utils/common.hpp"
 #include "utils/error.hpp"
-#include "utils/microfmt.hpp"
 
-#if IS_WINDOWS
- #include <windows.h>
- #include <io.h>
-#else
- #include <sys/stat.h>
- #include <unistd.h>
-#endif
+
 
 namespace cpptrace {
 namespace detail {
-    inline bool isatty(int fd) {
-        #if IS_WINDOWS
-         return _isatty(fd);
-        #else
-         return ::isatty(fd);
-        #endif
-    }
-
-    inline int fileno(std::FILE* stream) {
-        #if IS_WINDOWS
-         return _fileno(stream);
-        #else
-         return ::fileno(stream);
-        #endif
-    }
+    bool isatty(int fd);
+    int fileno(std::FILE* stream);
 
     inline std::vector<std::string> split(const std::string& str, const std::string& delims) {
         std::vector<std::string> vec;
@@ -162,21 +137,7 @@ namespace detail {
         return byte_swapper<T, sizeof(T)>{}(value);
     }
 
-    inline void enable_virtual_terminal_processing_if_needed() noexcept {
-        // enable colors / ansi processing if necessary
-        #if IS_WINDOWS
-         // https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences#example-of-enabling-virtual-terminal-processing
-         #ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
-          constexpr DWORD ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x4;
-         #endif
-         HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
-         DWORD dwMode = 0;
-         if(hOut == INVALID_HANDLE_VALUE) return;
-         if(!GetConsoleMode(hOut, &dwMode)) return;
-         if(dwMode != (dwMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING))
-         if(!SetConsoleMode(hOut, dwMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING)) return;
-        #endif
-    }
+    void enable_virtual_terminal_processing_if_needed() noexcept;
 
     constexpr unsigned n_digits(unsigned value) noexcept {
         return value < 10 ? 1 : 1 + n_digits(value / 10);
@@ -455,15 +416,7 @@ namespace detail {
     }
 
     // shamelessly stolen from stackoverflow
-    inline bool directory_exists(const std::string& path) {
-        #if IS_WINDOWS
-         DWORD dwAttrib = GetFileAttributesA(path.c_str());
-         return dwAttrib != INVALID_FILE_ATTRIBUTES && (dwAttrib & FILE_ATTRIBUTE_DIRECTORY);
-        #else
-         struct stat sb;
-         return stat(path.c_str(), &sb) == 0 && S_ISDIR(sb.st_mode);
-        #endif
-    }
+    bool directory_exists(const std::string& path);
 
     inline std::string basename(const std::string& path) {
         // Assumes no trailing /'s

--- a/test/unit/from_current.cpp
+++ b/test/unit/from_current.cpp
@@ -1,6 +1,4 @@
 #include <algorithm>
-#include <iomanip>
-#include <sstream>
 #include <string_view>
 #include <string>
 

--- a/test/unit/from_current_z.cpp
+++ b/test/unit/from_current_z.cpp
@@ -1,6 +1,4 @@
 #include <algorithm>
-#include <iomanip>
-#include <sstream>
 #include <string_view>
 #include <string>
 

--- a/test/unit/object_trace.cpp
+++ b/test/unit/object_trace.cpp
@@ -1,8 +1,4 @@
-#include <algorithm>
-#include <iomanip>
-#include <sstream>
-#include <string_view>
-#include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 #include <gtest/gtest-matchers.h>

--- a/test/unit/raw_trace.cpp
+++ b/test/unit/raw_trace.cpp
@@ -1,8 +1,5 @@
-#include <algorithm>
-#include <iomanip>
-#include <sstream>
-#include <string_view>
-#include <string>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 #include <gtest/gtest-matchers.h>

--- a/test/unit/stacktrace.cpp
+++ b/test/unit/stacktrace.cpp
@@ -1,8 +1,4 @@
-#include <algorithm>
-#include <iomanip>
-#include <sstream>
-#include <string_view>
-#include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 #include <gtest/gtest-matchers.h>

--- a/test/unit/traced_exception.cpp
+++ b/test/unit/traced_exception.cpp
@@ -1,6 +1,3 @@
-#include <algorithm>
-#include <iomanip>
-#include <sstream>
 #include <string_view>
 #include <string>
 


### PR DESCRIPTION
Thank you for the very useful library!

Few improvements:
- Better header hygiene
- Isolate `windows.h` to `.cpp` whenever possible
- Use `WIN32_LEAN_AND_MEAN`
- Remove unused headers

Tested on Windows with 
```
cmake .. -DCMAKE_BUILD_TYPE=Debug -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=1 
  -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS="-ftime-trace -Wall -Wextra -Wpedantic 
  -Wno-ignored-attributes" -DCMAKE_COLOR_DIAGNOSTICS=1 -DCPPTRACE_BUILD_TESTING=1 
  -DCPPTRACE_BUILD_BENCHMARKING=0
```

There's a lot more that can be improved if you are interested.