### PR TITLE
getpagesize() was removed from OSX (and posix)

### DIFF
--- a/src/from_current.cpp
+++ b/src/from_current.cpp
@@ -109,8 +109,6 @@ namespace cpptrace {
         int get_page_size() {
             #if defined(_SC_PAGESIZE)
                 return sysconf(_SC_PAGESIZE);
-            #elif defined(PAGE_SIZE)
-                return PAGE_SIZE;
             #else
                 return getpagesize();
             #endif

--- a/src/from_current.cpp
+++ b/src/from_current.cpp
@@ -107,10 +107,12 @@ namespace cpptrace {
         }
         #else
         int get_page_size() {
-            #ifdef getpagesize
-            return getpagesize();
+            #if defined(_SC_PAGESIZE)
+                return sysconf(_SC_PAGESIZE);
+            #elif defined(PAGE_SIZE)
+                return PAGE_SIZE;
             #else
-            return PAGE_SIZE;
+                return getpagesize();
             #endif
         }
         constexpr auto memory_readonly = PROT_READ;

--- a/src/from_current.cpp
+++ b/src/from_current.cpp
@@ -107,7 +107,11 @@ namespace cpptrace {
         }
         #else
         int get_page_size() {
+            #ifdef getpagesize
             return getpagesize();
+            #else
+            return PAGE_SIZE;
+            #endif
         }
         constexpr auto memory_readonly = PROT_READ;
         constexpr auto memory_readwrite = PROT_READ | PROT_WRITE;


### PR DESCRIPTION
PAGE_SIZE is a macro that can be used (which I'm guessing is defined to be `sysconf(_SC_PAGESIZE)` probably)

https://stackoverflow.com/questions/37897645/page-size-undeclared-c