### PR TITLE
Add missing #include <algorithm> in microfmt.hpp

### DIFF
--- a/src/utils/microfmt.hpp
+++ b/src/utils/microfmt.hpp
@@ -1,6 +1,7 @@
 #ifndef MICROFMT_HPP
 #define MICROFMT_HPP
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <cstring>


### PR DESCRIPTION
This fixes building latest cpptrace in macOS (https://github.com/jeremy-rifkin/microfmt/issues/1)