### PR TITLE
fix: actually use ccache binary returned by `find_program`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,10 @@ include(CheckCXXSourceCompiles)
 include(CheckCXXCompilerFlag)
 
 if(PROJECT_IS_TOP_LEVEL)
-  find_program(CCACHE_FOUND ccache)
-  if(CCACHE_FOUND)
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+  find_program(CCACHE_PROGRAM ccache)
+  if(CCACHE_PROGRAM)
+    set(CMAKE_C_COMPILER_LAUNCHER ${CCACHE_PROGRAM})
+    set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_PROGRAM})
   endif()
 endif()
 


### PR DESCRIPTION
The original code assumed that if `find_program` found `ccache`, then `ccache` must be in the `PATH`. However, `find_program` searches in a lot of different places. This can lead to situations where `ccache` is found, but the compile will fail because it's not in the path.

This change also uses `CMAKE_XXX_COMPILER_LAUNCHER` instead of `RULE_LAUNCH_COMPILE`, as the latter is for internal use only per the CMake docs.