### PR TITLE
Support using dladdr1 for safe trace resolution

### DIFF
--- a/src/binary/object.hpp
+++ b/src/binary/object.hpp
@@ -1,8 +1,9 @@
 #ifndef OBJECT_HPP
 #define OBJECT_HPP
 
-#include <vector>
 #include <cstdint>
+#include <string>
+#include <vector>
 
 namespace cpptrace {
 
@@ -17,6 +18,8 @@ namespace detail {
     std::vector<object_frame> get_frames_object_info(const std::vector<frame_ptr>& addresses);
 
     object_frame resolve_safe_object_frame(const safe_object_frame& frame);
+
+    std::string resolve_l_name(const char* l_name);
 }
 }
 


### PR DESCRIPTION
Currently, signal-safe tracing is limited to systems where the GLIC version is `>=2.35`. This is quite restrictive to older systems, and it results in traces silently not resolving even though that is possible (and already in `get_frame_object_info`) by using `dladdr1`.

Thus, I'm proposing using that function in older systems, as I managed to get safe traces working after this change. The issue with this, of course, is that these are no longer "safe", as the underlying calls involve memory allocations. These might be avoided, but that involves changes to functions like `[elf_]get_module_image_base` to make them safe.

In summary, this is not ready to merge in if we consider the `safe` in `get_safe_object_frame`, but it can get the discussion started. A simple solution to this might be to allow enabling this behind a flag.