### PR TITLE
Re-enable some dwarf 5 test cases now that upstream issues are resolved

### DIFF
--- a/ci/setup-prerequisites-unittest-macos.sh
+++ b/ci/setup-prerequisites-unittest-macos.sh
@@ -14,8 +14,8 @@ cd ..
 mkdir libdwarf
 cd libdwarf
 git init
-git remote add origin https://github.com/davea42/libdwarf-code.git
-git fetch --depth 1 origin 285d9d34f3e9f56cc1c487d0055f6dc54a9c54a1 # 0.11.0
+git remote add origin https://github.com/jeremy-rifkin/libdwarf-lite.git
+git fetch --depth 1 origin fe09ca800b988e2ff21225ac5e7468ceade2a30e # 0.11.1
 git checkout FETCH_HEAD
 mkdir build
 cd build

--- a/ci/setup-prerequisites-unittest.sh
+++ b/ci/setup-prerequisites-unittest.sh
@@ -14,8 +14,8 @@ cd ..
 mkdir libdwarf
 cd libdwarf
 git init
-git remote add origin https://github.com/davea42/libdwarf-code.git
-git fetch --depth 1 origin f4f6f782a06ab0618861cf0c4474989376c69c76 # 0.11.0 + trunk with some dwarf 5 fixes
+git remote add origin https://github.com/jeremy-rifkin/libdwarf-lite.git
+git fetch --depth 1 origin fe09ca800b988e2ff21225ac5e7468ceade2a30e # 0.11.1
 git checkout FETCH_HEAD
 mkdir build
 cd build

--- a/ci/unittest.py
+++ b/ci/unittest.py
@@ -133,19 +133,6 @@ def run_linux_matrix():
                 "stdlib": "libc++",
                 "sanitizers": "ON",
             },
-            {
-                # disabled until https://github.com/davea42/libdwarf-code/issues/259 is fixed
-                "compiler": "g++-10",
-                "build_type": "RelWithDebInfo",
-                "split_dwarf": "ON",
-                "dwarf_version": "5",
-            },
-            {
-                # disabled until https://github.com/davea42/libdwarf-code/issues/267 is fixed
-                "compiler": "clang++-18",
-                "split_dwarf": "ON",
-                "dwarf_version": "5",
-            },
         ]
     ).run(build_and_test)
 


### PR DESCRIPTION
Re-enables test cases that were disabled due to https://github.com/davea42/libdwarf-code/issues/259 and https://github.com/davea42/libdwarf-code/issues/267