### PR TITLE
test(stacktrace): make CPPTRACE_FORCE_INLINE static

### DIFF
--- a/test/unit/stacktrace.cpp
+++ b/test/unit/stacktrace.cpp
@@ -11,7 +11,7 @@ using namespace std::literals;
 #ifdef _MSC_VER
  #define CPPTRACE_FORCE_INLINE [[msvc::flatten]]
 #else
- #define CPPTRACE_FORCE_INLINE [[gnu::always_inline]]
+ #define CPPTRACE_FORCE_INLINE [[gnu::always_inline]] static
 #endif
 
 


### PR DESCRIPTION
This fixes compilation error:

```
> error: inlining failed in call to 'always_inline' 'int stacktrace_inline_resolution_2(std::vector<int>&)': function body can be overwritten at link time
```