### PR TITLE
Add missing `typeinfo` include

### DIFF
--- a/src/platform/exception_type.hpp
+++ b/src/platform/exception_type.hpp
@@ -7,6 +7,7 @@
 
 // libstdc++ and libc++
 #if defined(CPPTRACE_HAS_CXX_EXCEPTION_TYPE) && (IS_LIBSTDCXX || IS_LIBCXX)
+ #include <typeinfo>
  #include <cxxabi.h>
  #include "demangle/demangle.hpp"
 #endif


### PR DESCRIPTION
Hello,
as you know, I'm working on an integration of ``cpptrace`` into my own mocking framework. I've an exhaustive build-workflow with various compiler-configurations. One of these configs fails compiling due to this error:
```src/platform/exception_type.hpp:19:39: error: member access into incomplete type 'const std::type_info'```

This happens to be the case, when ``clang-16`` with c++23 and `-stdlib=libc++` is used.
see: https://github.com/DNKpp/mimicpp/actions/runs/12549146490/job/34989686008 and
https://github.com/DNKpp/mimicpp/actions/runs/12549146490/job/34989688648

This fixes the issue.