### PR TITLE
Support transforming stacktraces

### DIFF
--- a/include/cpptrace/basic.hpp
+++ b/include/cpptrace/basic.hpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 #include <iosfwd>
+#include <functional>
 
 #ifdef _WIN32
 #define CPPTRACE_EXPORT_ATTR __declspec(dllexport)
@@ -173,6 +174,7 @@ namespace cpptrace {
         std::vector<stacktrace_frame> frames;
         static stacktrace current(std::size_t skip = 0);
         static stacktrace current(std::size_t skip, std::size_t max_depth);
+        void transform(std::function<void (stacktrace_frame&)> const&);
         void print() const;
         void print(std::ostream& stream) const;
         void print(std::ostream& stream, bool color) const;

--- a/src/cpptrace.cpp
+++ b/src/cpptrace.cpp
@@ -168,6 +168,12 @@ namespace cpptrace {
         }
     }
 
+    void stacktrace::transform(std::function<void (stacktrace_frame&)> const& f) {
+        for(auto& frame : frames) {
+            f(frame);
+        }
+    }
+
     void stacktrace::print() const {
         get_default_formatter().print(*this);
     }

--- a/test/unit/tracing/stacktrace.cpp
+++ b/test/unit/tracing/stacktrace.cpp
@@ -42,6 +42,25 @@ TEST(Stacktrace, Basic) {
 }
 
 
+CPPTRACE_FORCE_NO_INLINE void stacktrace_transform() {
+    static volatile int lto_guard; lto_guard = lto_guard + 1;
+    auto trace = cpptrace::generate_trace();
+    ASSERT_GE(trace.frames.size(), 1);
+    trace.transform([](cpptrace::stacktrace_frame& frame) {
+        static size_t count = 0;
+        frame.symbol = std::to_string(count++);
+    });
+
+    size_t count = 0;
+    for(const auto& frame : trace.frames) {
+        EXPECT_EQ(frame.symbol, std::to_string(count++));
+    }
+}
+
+TEST(Stacktrace, Transform) {
+    stacktrace_transform();
+}
+
 
 // NOTE: returning something and then return stacktrace_multi_3(line_numbers) * rand(); is done to prevent TCO even
 // under LTO https://github.com/jeremy-rifkin/cpptrace/issues/179#issuecomment-2467302052


### PR DESCRIPTION
This support is added to the stacktrace itself, rather than the formatter, since allowing the formatter to change the stacktrace would require *every single* `stacktrace` and `stacktrace_frame` usage to require either an lvalue ref to non-const or an rvalue ref. This would break the existing API, which uses lvalue refs to const for everything.

Overall, the formatter is more of a view into a stacktrace, so while it was the first place I tried to put the transformation, it's not the best place. Instead, transforming the stacktrace itself can be done prior to formatting, without breaking any existing APIs.

You can see the commit where I tried this in the formatter here: https://github.com/jank-lang/cpptrace/commit/29258859a7435fde2c90de1dd2c23fedc88ced20

Note: I did my best to follow your style. It'd be great if you added a `.clang-format` file so that way nobody needs to worry about how many spaces to indent, where to place the `&` and `const`, etc.

I have tested this in jank, as well the unit test. We're currently doing this:

```cpp
  static void print_exception_stack_trace()
  {
    auto trace{ cpptrace::from_current_exception() };
    trace.transform(&strip_symbol);
    formatter.print(trace);
  }
```

This closes #227.