### PR TITLE
Add move-based frame transformation

### DIFF
--- a/include/cpptrace/formatting.hpp
+++ b/include/cpptrace/formatting.hpp
@@ -46,6 +46,7 @@ namespace cpptrace {
         formatter& columns(bool);
         formatter& filtered_frame_placeholders(bool);
         formatter& filter(std::function<bool(const stacktrace_frame&)>);
+        formatter& transform(std::function<stacktrace_frame(stacktrace_frame&&)>);
 
         std::string format(const stacktrace_frame&) const;
         std::string format(const stacktrace_frame&, bool color) const;

--- a/test/unit/lib/formatting.cpp
+++ b/test/unit/lib/formatting.cpp
@@ -255,6 +255,33 @@ TEST(FormatterTest, DontShowFilteredFrames) {
     );
 }
 
+TEST(FormatterTest, Transforming) {
+    auto formatter = cpptrace::formatter{}
+        .transform([](cpptrace::stacktrace_frame &&frame) {
+            static size_t count = 0;
+            frame.symbol = cpptrace::microfmt::format("sym{}", count++);
+            return std::move(frame);
+        });
+    auto res = split(formatter.format(make_test_stacktrace()), "\n");
+    EXPECT_THAT(
+        res,
+        ElementsAre(
+            "Stack trace (most recent call first):",
+            "#0 0x0000000000000001 in sym0 at foo.cpp:20:30",
+            "#1 0x0000000000000002 in sym1 at bar.cpp:30:40",
+            "#2 0x0000000000000003 in sym2 at foo.cpp:40:25"
+        )
+    );
+
+    auto frame_res = split(formatter.format(make_test_stacktrace().frames[1]), "\n");
+    EXPECT_THAT(
+        frame_res,
+        ElementsAre(
+            "0x0000000000000002 in sym3 at bar.cpp:30:40"
+        )
+    );
+}
+
 TEST(FormatterTest, MoveSemantics) {
     auto formatter = cpptrace::formatter{}
         .filter([] (const cpptrace::stacktrace_frame& frame) -> bool {


### PR DESCRIPTION
This could have been added directly in `print_frame_inner`, so we only need to add it in one place. However, by adding it in `print_internal`, prior to filtering, we allow transformation and filtering to cooperate. This allows a transformer to modify a frame such that it can later be marked for filtering, which would avoid duplicated code between those functions.

I don't have this use case right now, but it made sense from an overall product design perspective.

This closes #227. This closes #228.

Perf difference between this and #228 is nominal. Pick whichever you like more.