### PR TITLE
Fix dealloc invalid dwarf_formstring

### DIFF
--- a/src/symbols/dwarf/dwarf.hpp
+++ b/src/symbols/dwarf/dwarf.hpp
@@ -149,12 +149,9 @@ namespace libdwarf {
                 auto attwrapper = raii_wrap(attr, [] (Dwarf_Attribute attr) { dwarf_dealloc_attribute(attr); });
                 char* raw_str;
                 VERIFY(wrap(dwarf_formstring, attr, &raw_str) == DW_DLV_OK);
-                auto strwrapper = raii_wrap(raw_str, [this] (char* str) { dwarf_dealloc(dbg, str, DW_DLA_STRING); });
-                std::string str = raw_str;
-                return str;
-            } else {
-                return nullopt;
+                return std::string(raw_str);
             }
+            return nullopt;
         }
 
         optional<Dwarf_Unsigned> get_unsigned_attribute(Dwarf_Half attr_num) const {
@@ -166,9 +163,8 @@ namespace libdwarf {
                 Dwarf_Unsigned val;
                 VERIFY(wrap(dwarf_formudata, attr, &val) == DW_DLV_OK);
                 return val;
-            } else {
-                return nullopt;
             }
+            return nullopt;
         }
 
         bool has_attr(Dwarf_Half attr_num) const {


### PR DESCRIPTION
Hi team. Thanks for this fantastic library. A lot of great work here =).

I encountered an issue while generating the stack trace during a Qt crash handler. In particular, after debugging through the frame resolve, I found that while resolving string attributes in dwarf, the ``raii_wrap`` handler, ``dwarf_dealloc, `` attempted to free invalid memory, crashing.

https://github.com/jeremy-rifkin/cpptrace/blob/88d75647903b8fe9383601d1cf87a98016e9041b/src/symbols/dwarf/dwarf.hpp#L151-L156

### dwarf_formstring documentation

From the libdwarf documentation, specifically ``dwarf_formstring()``:
```
Returns a pointer to a string form attribute.
The pointer may point to .debug_str and does not require the caller to deallocate it.
```

**Docs:** On success, ``dwarf_formstring`` puts a pointer to a string existing in an appropriate ``DWARF`` section into ``dw_returned_string``. **Never free() or dealloc the returned string.** [[see docs here]](https://www.prevanders.net/libdwarfdoc/group__attrform.html#gac7aa81fddee67cb57133ba716bc3c0f7) Which ``dwarf_dealloc`` happens to be doing, and so, it crashes as we encounter undefined behavior.

### RCA and fix

* The result of ``dwarf_formstring()`` is not always dynamically allocated by libdwarf. In particular, it may point to .debug_str or static data, and the documentation explicitly states it does not require manual deallocation.

* The previous use of ``raii_wrap`` to call ``dwarf_dealloc(dbg, str, DW_DLA_STRING)`` results in undefined behavior and causes crashes in certain scenarios.

This change avoids manual deallocation and safely returns a copied ``std::string``.

### Example of my crash

```
#0  0x00007ff70c945b81 in QList<QPointF>::last() at C:/Qt/6.8.3/mingw_64/include/QtCore/qlist.h:653:24
#1  0x00007ff70c77ebf1 in BordeSegmentoAreaHormigonSeccionTransversalMuro::modificarCoordenada(int, double, double) at X.cpp:236:73
#2  0x00007ff70c782c23 in SegmentoAreaHormigonSeccionTransversalMuro::modificarPropiedades(int, QList<double> const&) const at Y.cpp:312:78
#3  0x00007ff70c77d3fd in AreaHormigonSeccionTransversalMuro::modificarSegmentosAreaHormigon(int, QList<double> const&) const at Z.cpp:162:37
#4  0x00007ff70c72a052 in SeccionTransversalMuro::ejecutarAccionEnBordesSegmentoAreaHormigon(int, int) at XX:2517:60
#5  0x00007ff70c720ad1 in SeccionTransversalMuro::ejecutarAccionEnComponenteSeleccionada(int, QString const&, int, int) at XX:654:71
#6  0x00007ff70c75671f in ProyectoSmartBD_AS::ejecutarAccionEnComponenteSeleccionadaSeccionTransversalMuro(QString const&, QString const&, int, QString const&, int, int) const at XY:735:140
#7  0x00007ff70c70ca57 in GraphicsViewSeccionTransversalMuro::eventoSobreBordeSegmentoAreaHormigonSeccionTransversalMuro(QMouseEvent*, int) at XZ.cpp:912:97
#8  0x00007ff70c70a411 in GraphicsViewSeccionTransversalMuro::wheelEvent(QWheelEvent*) at XZ:355:77
#9  0x00007ffa55e5700f in ZN7QWidget5eventEP6QEvent at C:\Qt\6.8.3\mingw_64\bin\Qt6Widgets.dll
#10 0x00007ffa55eca7c8 in ZN6QFrame5eventEP6QEvent at C:\Qt\6.8.3\mingw_64\bin\Qt6Widgets.dll
#11 0x00007ffa5e962727 in ZN23QCoreApplicationPrivate29sendThroughObjectEventFiltersEP7QObjectP6QEvent at C:\Qt\6.8.3\mingw_64\bin\Qt6Core.dll
#12 0x00007ffa55e06344 in ZN19QApplicationPrivate13notify_helperEP7QObjectP6QEvent at C:\Qt\6.8.3\mingw_64\bin\Qt6Widgets.dll
#13 0x00007ffa55e101ee in ZN12QApplication6notifyEP7QObjectP6QEvent at C:\Qt\6.8.3\mingw_64\bin\Qt6Widgets.dll
#14 0x00007ffa5e9629e9 in ZN16QCoreApplication15notifyInternal2EP7QObjectP6QEvent at C:\Qt\6.8.3\mingw_64\bin\Qt6Core.dll
#15 0x00007ffa55e65f1a in ZN14QWidgetPrivate10scrollRectERK5QRectii at C:\Qt\6.8.3\mingw_64\bin\Qt6Widgets.dll
#16 0x00007ffa55e6745b in ZN14QWidgetPrivate10scrollRectERK5QRectii at C:\Qt\6.8.3\mingw_64\bin\Qt6Widgets.dll
#17 0x00007ffa55e06354 in ZN19QApplicationPrivate13notify_helperEP7QObjectP6QEvent at C:\Qt\6.8.3\mingw_64\bin\Qt6Widgets.dll
#18 0x00007ffa5e9629e9 in ZN16QCoreApplication15notifyInternal2EP7QObjectP6QEvent at C:\Qt\6.8.3\mingw_64\bin\Qt6Core.dll
#19 0x00007ffa573408c0 in ZN22QGuiApplicationPrivate17processWheelEventEPN29QWindowSystemInterfacePrivate10WheelEventE at C:\Qt\6.8.3\mingw_64\bin\Qt6Gui.dll
#20 0x00007ffa573946cb in ZN22QWindowSystemInterface22sendWindowSystemEventsE6QFlagsIN10QEventLoop17ProcessEventsFlagEE at C:\Qt\6.8.3\mingw_64\bin\Qt6Gui.dll
#21 0x00007ffa5eb16066 in ZN21QEventDispatcherWin3213processEventsE6QFlagsIN10QEventLoop17ProcessEventsFlagEE at C:\Qt\6.8.3\mingw_64\bin\Qt6Core.dll
#22 0x00007ffa576ba908 in ZN26QWindowsGuiEventDispatcher13processEventsE6QFlagsIN10QEventLoop17ProcessEventsFlagEE at C:\Qt\6.8.3\mingw_64\bin\Qt6Gui.dll
#23 0x00007ffa5e96d6d1 in ZN10QEventLoop4execE6QFlagsINS_17ProcessEventsFlagEE at C:\Qt\6.8.3\mingw_64\bin\Qt6Core.dll
#24 0x00007ffa5e96b6a1 in ZN16QCoreApplication4execEv at C:\Qt\6.8.3\mingw_64\bin\Qt6Core.dll
#25 0x00007ff70c6e1558 in main at ZZ:36:34
#26 0x00007ff70c6e12ee at APP.exe
#27 0x00007ff70c6e1405 at APP.exe
#28 0x00007ffb4082e8d6 in BaseThreadInitThunk at C:\WINDOWS\System32\KERNEL32.DLL
#29 0x00007ffb41f314fb in RtlUserThreadStart at C:\WINDOWS\SYSTEM32\ntdll.dll
```

The crash happened while trying to get ``subprogram_symbol`` of ``"_ZN5QListI7QPointFE4lastEv"``, which calls ``die.get_string_attribute()``. With this fix, it succeeds, returning ``"QList<QPointF>::last()"`` after demangle.
