### PR TITLE
Remove unnecessary header from program_name.hpp

### DIFF
--- a/src/platform/program_name.hpp
+++ b/src/platform/program_name.hpp
@@ -68,7 +68,6 @@ namespace detail {
 
 #elif IS_LINUX
 
-#include <linux/limits.h>
 #include <sys/types.h>
 #include <unistd.h>
 


### PR DESCRIPTION
This header file appears to be unused. Even if it were used, the standardized `limits.h` header should be preferred if possible.

Some Linux distros ship these Linux specific headers in a dedicated package. This leads to an unnecessary additional compile time dependency.

I have `grep`ped through the codebase and have found no usage of `NR_OPEN`, `NGROUPS_MAX`, `ARG_MAX`, `LINK_MAX`, `MAX_CANON`, `MAX_INPUT`, `NAME_MAX`, `PATH_MAX`, `PIPE_BUF`, `XATTR_NAME_MAX`, `XATTR_SIZE_MAX` or `XATTR_LIST_MAX` (macros defined by `linux/limits.h`). Not even the commonly used `PATH_MAX` is in use here. But I may have overlooked something. 