### PR TITLE
remove_maybe-uninitialized_warnings for gcc 9.3.1

### DIFF
--- a/src/utils/optional.hpp
+++ b/src/utils/optional.hpp
@@ -34,7 +34,7 @@ namespace detail {
         using value_type = well_behaved<T>;
 
         union {
-            char x;
+            char x{};
             value_type uvalue;
         };
 


### PR DESCRIPTION
see below:
![image](https://github.com/user-attachments/assets/01035048-08a7-4996-a76c-2e09f339803f)
