### PR TITLE
replaces Unix Makefiles with Ninja

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: dependencies
       run: |
-           sudo apt install gcc-10 g++-10 libgcc-10-dev libunwind8-dev
+           sudo apt install gcc-10 g++-10 libgcc-10-dev libunwind8-dev ninja-build
            pip3 install colorama
     - name: libdwarf
       run: |
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: dependencies
       run: |
-            sudo apt install gcc-10 g++-10 libgcc-10-dev libunwind8-dev
+            sudo apt install gcc-10 g++-10 libgcc-10-dev libunwind8-dev ninja-build
             pip3 install colorama
     - name: libdwarf
       run: |
@@ -125,7 +125,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: dependencies
       run: |
-           sudo apt install gcc-10 g++-10 libgcc-10-dev libunwind8-dev
+           sudo apt install gcc-10 g++-10 libgcc-10-dev libunwind8-dev ninja-build
            pip3 install colorama
     - name: libdwarf
       run: |
@@ -261,20 +261,20 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: dependencies
-      run: sudo apt install gcc-11 g++-11 libgcc-11-dev
+      run: sudo apt install gcc-11 g++-11 libgcc-11-dev ninja-build
     - name: build
       run: |
            mkdir -p build
            cd build
-           cmake .. -DCMAKE_CXX_COMPILER=${{matrix.compiler}} -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=foo
-           make -j
-           make install
+           cmake .. -GNinja -DCMAKE_CXX_COMPILER=${{matrix.compiler}} -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=foo
+           ninja
+           ninja install
            mkdir -p ../test/speedtest/build
            cd ../test/speedtest/build
            cmake .. \
             -DCMAKE_BUILD_TYPE=Debug \
             ${{matrix.config}}
-           make -j
+           ninja -j
     - name: speedtest
       working-directory: test/speedtest/build
       run: |
@@ -298,8 +298,8 @@ jobs:
            cp -rv cpptrace/test/fetchcontent-integration .
            mkdir fetchcontent-integration/build
            cd fetchcontent-integration/build
-           cmake .. -DCMAKE_BUILD_TYPE=Debug -DCPPTRACE_TAG=$tag -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCPPTRACE_WERROR_BUILD=On
-           make
+           cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug -DCPPTRACE_TAG=$tag -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCPPTRACE_WERROR_BUILD=On
+           ninja
            ./main
   test-linux-findpackage:
     runs-on: ubuntu-22.04
@@ -315,14 +315,14 @@ jobs:
            tag=$(git rev-parse --abbrev-ref HEAD)
            mkdir build
            cd build
-           cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCPPTRACE_WERROR_BUILD=On
-           sudo make -j install
+           cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCPPTRACE_WERROR_BUILD=On
+           sudo ninja -j install
            cd ../..
            cp -rv cpptrace/test/findpackage-integration .
            mkdir findpackage-integration/build
            cd findpackage-integration/build
            cmake .. -DCMAKE_BUILD_TYPE=Debug
-           make
+           ninja
            ./main
   test-linux-add_subdirectory:
     runs-on: ubuntu-22.04
@@ -340,8 +340,8 @@ jobs:
            cp -rv cpptrace add_subdirectory-integration
            mkdir add_subdirectory-integration/build
            cd add_subdirectory-integration/build
-           cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCPPTRACE_WERROR_BUILD=On
-           make
+           cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCPPTRACE_WERROR_BUILD=On
+           ninja
            ./main
 
   test-macos-fetchcontent:
@@ -361,8 +361,8 @@ jobs:
            cp -rv cpptrace/test/fetchcontent-integration .
            mkdir fetchcontent-integration/build
            cd fetchcontent-integration/build
-           cmake .. -DCMAKE_BUILD_TYPE=Debug -DCPPTRACE_TAG=$tag -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCPPTRACE_WERROR_BUILD=On
-           make
+           cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug -DCPPTRACE_TAG=$tag -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCPPTRACE_WERROR_BUILD=On
+           ninja
            ./main
   test-macos-findpackage:
     runs-on: macos-14
@@ -379,14 +379,14 @@ jobs:
            echo $tag
            mkdir build
            cd build
-           cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCPPTRACE_WERROR_BUILD=On
-           sudo make -j install
+           cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCPPTRACE_WERROR_BUILD=On
+           sudo ninja -j install
            cd ../..
            cp -rv cpptrace/test/findpackage-integration .
            mkdir findpackage-integration/build
            cd findpackage-integration/build
            cmake .. -DCMAKE_BUILD_TYPE=Debug
-           make
+           ninja
            ./main
   test-macos-add_subdirectory:
     runs-on: macos-14
@@ -404,8 +404,8 @@ jobs:
            cp -rv cpptrace add_subdirectory-integration
            mkdir add_subdirectory-integration/build
            cd add_subdirectory-integration/build
-           cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCPPTRACE_WERROR_BUILD=On
-           make
+           cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCPPTRACE_WERROR_BUILD=On
+           ninja
            ./main
 
   test-mingw-fetchcontent:
@@ -425,8 +425,8 @@ jobs:
            cp -Recurse cpptrace/test/fetchcontent-integration .
            mkdir fetchcontent-integration/build
            cd fetchcontent-integration/build
-           cmake .. -DCMAKE_BUILD_TYPE=Debug -DCPPTRACE_TAG="$tag" "-GUnix Makefiles" -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCPPTRACE_WERROR_BUILD=On
-           make
+           cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug -DCPPTRACE_TAG="$tag" -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCPPTRACE_WERROR_BUILD=On
+           ninja
            .\main.exe
   test-mingw-findpackage:
     runs-on: windows-2022
@@ -443,14 +443,14 @@ jobs:
            echo $tag
            mkdir build
            cd build
-           cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=${{matrix.shared}} "-GUnix Makefiles" -DCMAKE_INSTALL_PREFIX=C:/foo -DCPPTRACE_WERROR_BUILD=On
-           make -j install
+           cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCMAKE_INSTALL_PREFIX=C:/foo -DCPPTRACE_WERROR_BUILD=On
+           ninja -j install
            cd ../..
            mv cpptrace/test/findpackage-integration .
            mkdir findpackage-integration/build
            cd findpackage-integration/build
-           cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=C:/foo "-GUnix Makefiles"
-           make
+           cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=C:/foo
+           ninja
            ./main
   test-mingw-add_subdirectory:
     runs-on: windows-2022
@@ -468,8 +468,8 @@ jobs:
            cp -Recurse cpptrace add_subdirectory-integration
            mkdir add_subdirectory-integration/build
            cd add_subdirectory-integration/build
-           cmake .. -DCMAKE_BUILD_TYPE=Debug "-GUnix Makefiles" -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCPPTRACE_WERROR_BUILD=On
-           make
+           cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCPPTRACE_WERROR_BUILD=On
+           ninja
            .\main.exe
   test-windows-fetchcontent:
     runs-on: windows-2022
@@ -559,7 +559,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: dependencies
       run: |
-           sudo apt install gcc-10 g++-10 libgcc-10-dev ninja-build libc++-dev
+           sudo apt install gcc-10 g++-10 libgcc-10-dev ninja-build libc++-dev ninja-build
            cd ..
            cpptrace/ci/setup-prerequisites-unittest.sh
     - name: build and test
@@ -598,7 +598,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: dependencies
       run: |
-            sudo apt install gcc-10 g++-10 libgcc-10-dev ninja-build libc++-dev
+            sudo apt install gcc-10 g++-10 libgcc-10-dev ninja-build libc++-dev ninja-build
             cd ..
             cpptrace/ci/setup-prerequisites-unittest.sh
     - name: build and test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,7 +274,7 @@ jobs:
            cmake .. \
             -DCMAKE_BUILD_TYPE=Debug \
             ${{matrix.config}}
-           ninja -j
+           ninja
     - name: speedtest
       working-directory: test/speedtest/build
       run: |
@@ -316,7 +316,7 @@ jobs:
            mkdir build
            cd build
            cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCPPTRACE_WERROR_BUILD=On
-           sudo ninja -j install
+           sudo ninja install
            cd ../..
            cp -rv cpptrace/test/findpackage-integration .
            mkdir findpackage-integration/build
@@ -380,7 +380,7 @@ jobs:
            mkdir build
            cd build
            cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCPPTRACE_WERROR_BUILD=On
-           sudo ninja -j install
+           sudo ninja install
            cd ../..
            cp -rv cpptrace/test/findpackage-integration .
            mkdir findpackage-integration/build
@@ -444,7 +444,7 @@ jobs:
            mkdir build
            cd build
            cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCMAKE_INSTALL_PREFIX=C:/foo -DCPPTRACE_WERROR_BUILD=On
-           ninja -j install
+           ninja install
            cd ../..
            mv cpptrace/test/findpackage-integration .
            mkdir findpackage-integration/build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,6 +272,7 @@ jobs:
            mkdir -p ../test/speedtest/build
            cd ../test/speedtest/build
            cmake .. \
+            -GNinja
             -DCMAKE_BUILD_TYPE=Debug \
             ${{matrix.config}}
            ninja
@@ -321,7 +322,7 @@ jobs:
            cp -rv cpptrace/test/findpackage-integration .
            mkdir findpackage-integration/build
            cd findpackage-integration/build
-           cmake .. -DCMAKE_BUILD_TYPE=Debug
+           cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug
            ninja
            ./main
   test-linux-add_subdirectory:
@@ -385,7 +386,7 @@ jobs:
            cp -rv cpptrace/test/findpackage-integration .
            mkdir findpackage-integration/build
            cd findpackage-integration/build
-           cmake .. -DCMAKE_BUILD_TYPE=Debug
+           cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug
            ninja
            ./main
   test-macos-add_subdirectory:
@@ -449,7 +450,7 @@ jobs:
            mv cpptrace/test/findpackage-integration .
            mkdir findpackage-integration/build
            cd findpackage-integration/build
-           cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=C:/foo
+           cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=C:/foo
            ninja
            ./main
   test-mingw-add_subdirectory:
@@ -490,7 +491,7 @@ jobs:
            cp -Recurse cpptrace/test/fetchcontent-integration .
            mkdir fetchcontent-integration/build
            cd fetchcontent-integration/build
-           cmake .. -DCMAKE_BUILD_TYPE=Debug -DCPPTRACE_TAG="$tag" -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCPPTRACE_WERROR_BUILD=On
+           cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug -DCPPTRACE_TAG="$tag" -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCPPTRACE_WERROR_BUILD=On
            msbuild demo_project.sln
            .\Debug\main.exe
   test-windows-findpackage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,7 @@ jobs:
            mkdir -p ../test/speedtest/build
            cd ../test/speedtest/build
            cmake .. \
-            -GNinja
+            -GNinja \
             -DCMAKE_BUILD_TYPE=Debug \
             ${{matrix.config}}
            ninja
@@ -491,7 +491,7 @@ jobs:
            cp -Recurse cpptrace/test/fetchcontent-integration .
            mkdir fetchcontent-integration/build
            cd fetchcontent-integration/build
-           cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug -DCPPTRACE_TAG="$tag" -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCPPTRACE_WERROR_BUILD=On
+           cmake .. -DCMAKE_BUILD_TYPE=Debug -DCPPTRACE_TAG="$tag" -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCPPTRACE_WERROR_BUILD=On
            msbuild demo_project.sln
            .\Debug\main.exe
   test-windows-findpackage:

--- a/.github/workflows/sonarlint.yml
+++ b/.github/workflows/sonarlint.yml
@@ -20,8 +20,8 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake .. -DCMAKE_BUILD_TYPE=Debug -DCPPTRACE_BUILD_TESTING=On -DCMAKE_EXPORT_COMPILE_COMMANDS=On -DCMAKE_CXX_STANDARD=11
-        make -j
+        cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug -DCPPTRACE_BUILD_TESTING=On -DCMAKE_EXPORT_COMPILE_COMMANDS=On -DCMAKE_CXX_STANDARD=11
+        ninja
         cd ..
     - name: Run sonar-scanner
       env:


### PR DESCRIPTION
CMake doesn't support building C++20 modules with Makefiles, so we switch to Ninja.