### PR TITLE
Fix clang 32bit builds

### DIFF
--- a/src/binary/elf.hpp
+++ b/src/binary/elf.hpp
@@ -17,9 +17,9 @@ CPPTRACE_BEGIN_NAMESPACE
 namespace detail {
 
     constexpr bool is_32bit_v{INTPTR_MAX < INT64_MAX};
-    using Elf_Addr = std::conditional_t<is_32bit_v, std::uint32_t, std::uint64_t>;
-    using Elf_Off = std::conditional_t<is_32bit_v, std::uint32_t, std::uint64_t>;
-    using Elf_Xword = std::conditional_t<is_32bit_v, std::uint32_t, std::uint64_t>;
+    using Elf_Addr = typename std::conditional<is_32bit_v, std::uint32_t, std::uint64_t>::type;
+    using Elf_Off = typename std::conditional<is_32bit_v, std::uint32_t, std::uint64_t>::type;
+    using Elf_Xword = typename std::conditional<is_32bit_v, std::uint32_t, std::uint64_t>::type;
 
     // TODO: make methods const and a bunch of members mutable
     class elf {

--- a/src/binary/elf.hpp
+++ b/src/binary/elf.hpp
@@ -15,6 +15,12 @@
 
 CPPTRACE_BEGIN_NAMESPACE
 namespace detail {
+
+    constexpr bool is_32bit_v{INTPTR_MAX < INT64_MAX};
+    using Elf_Addr = std::conditional_t<is_32bit_v, std::uint32_t, std::uint64_t>;
+    using Elf_Off = std::conditional_t<is_32bit_v, std::uint32_t, std::uint64_t>;
+    using Elf_Xword = std::conditional_t<is_32bit_v, std::uint32_t, std::uint64_t>;
+
     // TODO: make methods const and a bunch of members mutable
     class elf {
         std::unique_ptr<base_file> file;
@@ -36,10 +42,10 @@ namespace detail {
         struct section_info {
             uint32_t sh_name;
             uint32_t sh_type;
-            uint64_t sh_addr;
-            uint64_t sh_offset;
-            uint64_t sh_size;
-            uint64_t sh_entsize;
+            Elf_Addr sh_addr;
+            Elf_Off sh_offset;
+            Elf_Xword sh_size;
+            Elf_Xword sh_entsize;
             uint32_t sh_link;
         };
         bool tried_to_load_sections = false;

--- a/src/binary/elf.hpp
+++ b/src/binary/elf.hpp
@@ -15,11 +15,9 @@
 
 CPPTRACE_BEGIN_NAMESPACE
 namespace detail {
-
-    constexpr bool is_32bit_v{INTPTR_MAX < INT64_MAX};
-    using Elf_Addr = typename std::conditional<is_32bit_v, std::uint32_t, std::uint64_t>::type;
-    using Elf_Off = typename std::conditional<is_32bit_v, std::uint32_t, std::uint64_t>::type;
-    using Elf_Xword = typename std::conditional<is_32bit_v, std::uint32_t, std::uint64_t>::type;
+    using Elf_Addr = std::uintptr_t;
+    using Elf_Off = std::uintptr_t;
+    using Elf_Xword = std::size_t;
 
     // TODO: make methods const and a bunch of members mutable
     class elf {


### PR DESCRIPTION
As already reported on the discord, 32bit with clang currently fail compiling:
![image](https://github.com/user-attachments/assets/2d486740-0430-4fc2-965d-01fb0ccc5b24)

This is my attempt to fix this issue, without blindly static-casting to the target type.