### PR TITLE
Implement #259: add formatter option 'break_before_filename'

### DIFF
--- a/include/cpptrace/formatting.hpp
+++ b/include/cpptrace/formatting.hpp
@@ -56,6 +56,7 @@ CPPTRACE_BEGIN_NAMESPACE
         formatter& filtered_frame_placeholders(bool);
         formatter& filter(std::function<bool(const stacktrace_frame&)>);
         formatter& transform(std::function<stacktrace_frame(stacktrace_frame)>);
+        formatter& break_before_filename(bool do_break = true);
 
         std::string format(const stacktrace_frame&) const;
         std::string format(const stacktrace_frame&, bool color) const;
@@ -67,8 +68,12 @@ CPPTRACE_BEGIN_NAMESPACE
         void print(const stacktrace_frame&, bool color) const;
         void print(std::ostream&, const stacktrace_frame&) const;
         void print(std::ostream&, const stacktrace_frame&, bool color) const;
+        // The last argument is the indent to use for the filename, if break_before_filename is set
+        void print(std::ostream&, const stacktrace_frame&, bool color, size_t filename_indent) const;
         void print(std::FILE*, const stacktrace_frame&) const;
         void print(std::FILE*, const stacktrace_frame&, bool color) const;
+        // The last argument is the indent to use for the filename, if break_before_filename is set
+        void print(std::FILE*, const stacktrace_frame&, bool color, size_t filename_indent) const;
 
         void print(const stacktrace&) const;
         void print(const stacktrace&, bool color) const;

--- a/include/cpptrace/formatting.hpp
+++ b/include/cpptrace/formatting.hpp
@@ -60,6 +60,8 @@ CPPTRACE_BEGIN_NAMESPACE
 
         std::string format(const stacktrace_frame&) const;
         std::string format(const stacktrace_frame&, bool color) const;
+        // The last argument is the indent to use for the filename, if break_before_filename is set
+        std::string format(const stacktrace_frame&, bool color, size_t filename_indent) const;
 
         std::string format(const stacktrace&) const;
         std::string format(const stacktrace&, bool color) const;

--- a/src/formatting.cpp
+++ b/src/formatting.cpp
@@ -435,6 +435,9 @@ CPPTRACE_BEGIN_NAMESPACE
     std::string formatter::format(const stacktrace_frame& frame, bool color) const {
         return pimpl->format(frame, color);
     }
+    std::string formatter::format(const stacktrace_frame& frame, bool color, size_t filename_indent) const {
+        return pimpl->format(frame, color, filename_indent);
+    }
 
     std::string formatter::format(const stacktrace& trace) const {
         return pimpl->format(trace);

--- a/test/unit/lib/formatting.cpp
+++ b/test/unit/lib/formatting.cpp
@@ -21,8 +21,10 @@ namespace {
 
 #if UINTPTR_MAX > 0xffffffff
  #define ADDR_PREFIX "00000000"
+ #define PADDING_TAG "        "
  #define INLINED_TAG "(inlined)         "
 #else
+ #define PADDING_TAG ""
  #define ADDR_PREFIX ""
  #define INLINED_TAG "(inlined) "
 #endif
@@ -134,12 +136,12 @@ TEST(FormatterTest, BreakBeforeFilename) {
         split(formatter.format(make_test_stacktrace()), "\n"),
         ElementsAre(
             "Stack trace (most recent call first):",
-            "#0 0x0000000000000001 in foo()",
-            "                      at foo.cpp:20:30",
-            "#1 0x0000000000000002 in bar()",
-            "                      at bar.cpp:30:40",
-            "#2 0x0000000000000003 in main",
-            "                      at foo.cpp:40:25"
+            "#0 0x" ADDR_PREFIX "00000001 in foo()",
+            "     " PADDING_TAG "         at foo.cpp:20:30",
+            "#1 0x" ADDR_PREFIX "00000002 in bar()",
+            "     " PADDING_TAG "         at bar.cpp:30:40",
+            "#2 0x" ADDR_PREFIX "00000003 in main",
+            "     " PADDING_TAG "         at foo.cpp:40:25"
         )
     );
 }
@@ -174,12 +176,12 @@ TEST(FormatterTest, BreakBeforeFilenameInlines) {
         split(formatter.format(trace), "\n"),
         ElementsAre(
             "Stack trace (most recent call first):",
-            "#0 0x0000000000000001 in foo()",
-            "                      at foo.cpp:20:30",
-            "#1 (inlined)          in bar()",
-            "                      at bar.cpp:30:40",
-            "#2 0x0000000000000003 in main",
-            "                      at foo.cpp:40:25"
+            "#0 0x" ADDR_PREFIX "00000001 in foo()",
+            "     " PADDING_TAG "         at foo.cpp:20:30",
+            "#1 " INLINED_TAG " in bar()",
+            "     " PADDING_TAG "         at bar.cpp:30:40",
+            "#2 0x" ADDR_PREFIX "00000003 in main",
+            "     " PADDING_TAG "         at foo.cpp:40:25"
         )
     );
 }
@@ -194,30 +196,30 @@ TEST(FormatterTest, BreakBeforeFilenameLongTrace) {
         split(formatter.format(make_test_stacktrace(4)), "\n"),
         ElementsAre(
             "Stack trace (most recent call first):",
-            "#0  0x0000000000000001 in foo()",
-            "                       at foo.cpp:20:30",
-            "#1  0x0000000000000002 in bar()",
-            "                       at bar.cpp:30:40",
-            "#2  0x0000000000000003 in main",
-            "                       at foo.cpp:40:25",
-            "#3  0x0000000000000001 in foo()",
-            "                       at foo.cpp:20:30",
-            "#4  0x0000000000000002 in bar()",
-            "                       at bar.cpp:30:40",
-            "#5  0x0000000000000003 in main",
-            "                       at foo.cpp:40:25",
-            "#6  0x0000000000000001 in foo()",
-            "                       at foo.cpp:20:30",
-            "#7  0x0000000000000002 in bar()",
-            "                       at bar.cpp:30:40",
-            "#8  0x0000000000000003 in main",
-            "                       at foo.cpp:40:25",
-            "#9  0x0000000000000001 in foo()",
-            "                       at foo.cpp:20:30",
-            "#10 0x0000000000000002 in bar()",
-            "                       at bar.cpp:30:40",
-            "#11 0x0000000000000003 in main",
-            "                       at foo.cpp:40:25"
+            "#0  0x" ADDR_PREFIX "00000001 in foo()",
+            "     " PADDING_TAG "          at foo.cpp:20:30",
+            "#1  0x" ADDR_PREFIX "00000002 in bar()",
+            "     " PADDING_TAG "          at bar.cpp:30:40",
+            "#2  0x" ADDR_PREFIX "00000003 in main",
+            "     " PADDING_TAG "          at foo.cpp:40:25",
+            "#3  0x" ADDR_PREFIX "00000001 in foo()",
+            "     " PADDING_TAG "          at foo.cpp:20:30",
+            "#4  0x" ADDR_PREFIX "00000002 in bar()",
+            "     " PADDING_TAG "          at bar.cpp:30:40",
+            "#5  0x" ADDR_PREFIX "00000003 in main",
+            "     " PADDING_TAG "          at foo.cpp:40:25",
+            "#6  0x" ADDR_PREFIX "00000001 in foo()",
+            "     " PADDING_TAG "          at foo.cpp:20:30",
+            "#7  0x" ADDR_PREFIX "00000002 in bar()",
+            "     " PADDING_TAG "          at bar.cpp:30:40",
+            "#8  0x" ADDR_PREFIX "00000003 in main",
+            "     " PADDING_TAG "          at foo.cpp:40:25",
+            "#9  0x" ADDR_PREFIX "00000001 in foo()",
+            "     " PADDING_TAG "          at foo.cpp:20:30",
+            "#10 0x" ADDR_PREFIX "00000002 in bar()",
+            "     " PADDING_TAG "          at bar.cpp:30:40",
+            "#11 0x" ADDR_PREFIX "00000003 in main",
+            "     " PADDING_TAG "          at foo.cpp:40:25"
         )
     );
 }
@@ -235,12 +237,12 @@ TEST(FormatterTest, BreakBeforeFilenameColors) {
         split(formatter.format(make_test_stacktrace()), "\n"),
         ElementsAre(
             "Stack trace (most recent call first):",
-            "#0 \x1B[34m0x0000000000000001\x1B[0m in \x1B[33mfoo()\x1B[0m",
-            "                      at \x1B[32mfoo.cpp\x1B[0m:\x1B[34m20\x1B[0m:\x1B[34m30\x1B[0m",
-            "#1 \x1B[34m0x0000000000000002\x1B[0m in \x1B[33mbar()\x1B[0m",
-            "                      at \x1B[32mbar.cpp\x1B[0m:\x1B[34m30\x1B[0m:\x1B[34m40\x1B[0m",
-            "#2 \x1B[34m0x0000000000000003\x1B[0m in \x1B[33mmain\x1B[0m",
-            "                      at \x1B[32mfoo.cpp\x1B[0m:\x1B[34m40\x1B[0m:\x1B[34m25\x1B[0m"
+            "#0 \x1B[34m0x" ADDR_PREFIX "00000001\x1B[0m in \x1B[33mfoo()\x1B[0m",
+            "     " PADDING_TAG "         at \x1B[32mfoo.cpp\x1B[0m:\x1B[34m20\x1B[0m:\x1B[34m30\x1B[0m",
+            "#1 \x1B[34m0x" ADDR_PREFIX "00000002\x1B[0m in \x1B[33mbar()\x1B[0m",
+            "     " PADDING_TAG "         at \x1B[32mbar.cpp\x1B[0m:\x1B[34m30\x1B[0m:\x1B[34m40\x1B[0m",
+            "#2 \x1B[34m0x" ADDR_PREFIX "00000003\x1B[0m in \x1B[33mmain\x1B[0m",
+            "     " PADDING_TAG "         at \x1B[32mfoo.cpp\x1B[0m:\x1B[34m40\x1B[0m:\x1B[34m25\x1B[0m"
         )
     );
 }

--- a/test/unit/lib/formatting.cpp
+++ b/test/unit/lib/formatting.cpp
@@ -27,11 +27,13 @@ namespace {
  #define INLINED_TAG "(inlined) "
 #endif
 
-cpptrace::stacktrace make_test_stacktrace() {
+cpptrace::stacktrace make_test_stacktrace(size_t count = 1) {
     cpptrace::stacktrace trace;
-    trace.frames.push_back({0x1, 0x1001, {20}, {30}, "foo.cpp", "foo()", false});
-    trace.frames.push_back({0x2, 0x1002, {30}, {40}, "bar.cpp", "bar()", false});
-    trace.frames.push_back({0x3, 0x1003, {40}, {25}, "foo.cpp", "main", false});
+    for(size_t i = 0; i < count; i++) {
+        trace.frames.push_back({0x1, 0x1001, {20}, {30}, "foo.cpp", "foo()", false});
+        trace.frames.push_back({0x2, 0x1002, {30}, {40}, "bar.cpp", "bar()", false});
+        trace.frames.push_back({0x3, 0x1003, {40}, {25}, "foo.cpp", "main", false});
+    }
     return trace;
 }
 
@@ -121,6 +123,124 @@ TEST(FormatterTest, NoAddresses) {
             "#0 in foo() at foo.cpp:20:30",
             "#1 in bar() at bar.cpp:30:40",
             "#2 in main at foo.cpp:40:25"
+        )
+    );
+}
+
+TEST(FormatterTest, BreakBeforeFilename) {
+    auto formatter = cpptrace::formatter{}
+        .break_before_filename(true);
+    EXPECT_THAT(
+        split(formatter.format(make_test_stacktrace()), "\n"),
+        ElementsAre(
+            "Stack trace (most recent call first):",
+            "#0 0x0000000000000001 in foo()",
+            "                      at foo.cpp:20:30",
+            "#1 0x0000000000000002 in bar()",
+            "                      at bar.cpp:30:40",
+            "#2 0x0000000000000003 in main",
+            "                      at foo.cpp:40:25"
+        )
+    );
+}
+
+TEST(FormatterTest, BreakBeforeFilenameNoAddresses) {
+    auto formatter = cpptrace::formatter{}
+        .break_before_filename(true)
+        .addresses(cpptrace::formatter::address_mode::none);
+    // Check that if no address is present, the filename indent is reduced
+    EXPECT_THAT(
+        split(formatter.format(make_test_stacktrace()), "\n"),
+        ElementsAre(
+            "Stack trace (most recent call first):",
+            "#0 in foo()",
+            "   at foo.cpp:20:30",
+            "#1 in bar()",
+            "   at bar.cpp:30:40",
+            "#2 in main",
+            "   at foo.cpp:40:25"
+        )
+    );
+}
+
+TEST(FormatterTest, BreakBeforeFilenameInlines) {
+    auto formatter = cpptrace::formatter{}
+        .break_before_filename(true);
+
+    // Check that indentation is computed correctly when elements are inlined
+    auto trace = make_test_stacktrace();
+    trace.frames[1].is_inline = true;
+    EXPECT_THAT(
+        split(formatter.format(trace), "\n"),
+        ElementsAre(
+            "Stack trace (most recent call first):",
+            "#0 0x0000000000000001 in foo()",
+            "                      at foo.cpp:20:30",
+            "#1 (inlined)          in bar()",
+            "                      at bar.cpp:30:40",
+            "#2 0x0000000000000003 in main",
+            "                      at foo.cpp:40:25"
+        )
+    );
+}
+
+TEST(FormatterTest, BreakBeforeFilenameLongTrace) {
+    // Check that indentation is computed correctly for longer traces (where the
+    // frame number is padded)
+    auto formatter = cpptrace::formatter{}
+        .break_before_filename(true);
+
+    EXPECT_THAT(
+        split(formatter.format(make_test_stacktrace(4)), "\n"),
+        ElementsAre(
+            "Stack trace (most recent call first):",
+            "#0  0x0000000000000001 in foo()",
+            "                       at foo.cpp:20:30",
+            "#1  0x0000000000000002 in bar()",
+            "                       at bar.cpp:30:40",
+            "#2  0x0000000000000003 in main",
+            "                       at foo.cpp:40:25",
+            "#3  0x0000000000000001 in foo()",
+            "                       at foo.cpp:20:30",
+            "#4  0x0000000000000002 in bar()",
+            "                       at bar.cpp:30:40",
+            "#5  0x0000000000000003 in main",
+            "                       at foo.cpp:40:25",
+            "#6  0x0000000000000001 in foo()",
+            "                       at foo.cpp:20:30",
+            "#7  0x0000000000000002 in bar()",
+            "                       at bar.cpp:30:40",
+            "#8  0x0000000000000003 in main",
+            "                       at foo.cpp:40:25",
+            "#9  0x0000000000000001 in foo()",
+            "                       at foo.cpp:20:30",
+            "#10 0x0000000000000002 in bar()",
+            "                       at bar.cpp:30:40",
+            "#11 0x0000000000000003 in main",
+            "                       at foo.cpp:40:25"
+        )
+    );
+}
+
+TEST(FormatterTest, BreakBeforeFilenameColors) {
+    // Check that indentation is computed correctly with colors enabled
+    // (If microfmt is updated to count the number of characters printed,
+    // it will need to _exclude_ colors for the purposes of computing
+    // alignment)
+    auto formatter = cpptrace::formatter{}
+        .break_before_filename(true)
+        .colors(cpptrace::formatter::color_mode::always);
+
+    EXPECT_THAT(
+        split(formatter.format(make_test_stacktrace()), "\n"),
+        ElementsAre(
+            "Stack trace (most recent call first):",
+            "#0 \x1B[34m0x0000000000000001\x1B[0m in \x1B[33mfoo()\x1B[0m",
+            "                      at \x1B[32mfoo.cpp\x1B[0m:\x1B[34m20\x1B[0m:\x1B[34m30\x1B[0m",
+            "#1 \x1B[34m0x0000000000000002\x1B[0m in \x1B[33mbar()\x1B[0m",
+            "                      at \x1B[32mbar.cpp\x1B[0m:\x1B[34m30\x1B[0m:\x1B[34m40\x1B[0m",
+            "#2 \x1B[34m0x0000000000000003\x1B[0m in \x1B[33mmain\x1B[0m",
+            "                      at \x1B[32mfoo.cpp\x1B[0m:\x1B[34m40\x1B[0m:\x1B[34m25\x1B[0m"
         )
     );
 }

--- a/tools/symbol_tables/main.cpp
+++ b/tools/symbol_tables/main.cpp
@@ -74,10 +74,10 @@ void lookup_symbol(const options& options, cpptrace::frame_ptr address) {
     }
 }
 #elif IS_APPLE
-void dump_symbols(const std::filesystem::path&) {
+void dump_symbols(const options&) {
     fmt::println("Not implemented yet (TODO)");
 }
-void lookup_symbol(const std::filesystem::path&, cpptrace::frame_ptr) {
+void lookup_symbol(const options&, cpptrace::frame_ptr) {
     fmt::println("Not implemented yet (TODO)");
 }
 #else


### PR DESCRIPTION
This PR adds support for a `break_before_filename` option on the formatter (see #259 for examples & more information).

The following functions have been added to the API of the library:

```cpp
class formatter {
    // ...

    // When printing the stacktrace, inserts a linebreak prior after the symbol name,
    // and inserts enough whitespace to align the filename with the symbol name.
    formatter& break_before_filename(bool do_break = true);

    // Formats an individual frame, with the given amount of extra whitespace added before the filename
    // in the event of a linebreak. This is needed because oftentimes an individual frame is printed
    // _after_ some identifier, such as the index of the frame within the trace, and if this information
    // is not taken into account, the filename will be misaligned.
    std::string format(const stacktrace_frame&, bool color, size_t filename_indent) const;

    // Same as above, but to a std::ostream&
    void print(std::ostream&, const stacktrace_frame&, bool color, size_t filename_indent) const;
    
    // Same as above, but with std::FILE*
    void print(std::FILE*, const stacktrace_frame&, bool color, size_t filename_indent) const;
}
```
    
Unit tests were added in `test/unit/lib/formatting.cpp`.