### PR TITLE
Avoid using dynamically allocated vector for punctuators_and_operators

### DIFF
--- a/src/prune_symbol.cpp
+++ b/src/prune_symbol.cpp
@@ -60,7 +60,6 @@ namespace detail {
     }
 
     // http://eel.is/c++draft/lex.operators#nt:operator-or-punctuator
-    //
     // These must be ordered by length, longest first.
     const string_view punctuators_and_operators[] {
         // 3 character operators
@@ -120,7 +119,7 @@ namespace detail {
         "<",
         ">",
         ",",
-        "#",
+        "#", // extension for {lambda()#1}
     };
 
     const std::array<string_view, 2> anonymous_namespace_spellings = {"(anonymous namespace)", "`anonymous namespace'"};


### PR DESCRIPTION
I'm currently working on a memory profiler, and I noticed that 880 bytes was always being allocated at the start of any program that I tested. This allocation was due to `punctuators_and_operators`, inside cpptrace.

<img width="1548" height="404" alt="image" src="https://github.com/user-attachments/assets/5d218d65-0530-4d29-ad1f-24f5ce7a2090" />

I've created this MR to convert `punctuators_and_operators` into a statically allocated array, so that cpptrace doesn't do any allocations on initialization.