### PR TITLE
Removed windows compilation warning: 'WIN32_LEAN_AND_MEAN' redefined

### DIFF
--- a/src/unwind/unwind.hpp
+++ b/src/unwind/unwind.hpp
@@ -7,7 +7,9 @@
 #include <vector>
 
 #ifdef CPPTRACE_UNWIND_WITH_DBGHELP
- #define WIN32_LEAN_AND_MEAN
+ #ifndef WIN32_LEAN_AND_MEAN
+  #define WIN32_LEAN_AND_MEAN
+ #endif
  #include <windows.h>
 #endif
 


### PR DESCRIPTION
Removed this warning:
src/unwind/unwind.hpp:10:10: warning: 'WIN32_LEAN_AND_MEAN' redefined
Similar background like in https://github.com/jeremy-rifkin/cpptrace/pull/186