### PR TITLE
Fully isolate windows.h includes to source files

### DIFF
--- a/include/cpptrace/from_current.hpp
+++ b/include/cpptrace/from_current.hpp
@@ -6,7 +6,7 @@
 #include <utility>
 
 #ifdef _MSC_VER
- #include <windows.h>
+ #include <excpt.h>
 #endif
 
 #include <cpptrace/basic.hpp>
@@ -43,11 +43,11 @@ CPPTRACE_BEGIN_NAMESPACE
 
         #ifdef _MSC_VER
          CPPTRACE_EXPORT CPPTRACE_FORCE_NO_INLINE
-         int maybe_collect_trace(EXCEPTION_POINTERS* exception_ptrs, int filter_result);
+         int maybe_collect_trace(_EXCEPTION_POINTERS* exception_ptrs, int filter_result);
          CPPTRACE_EXPORT CPPTRACE_FORCE_NO_INLINE
-         void maybe_collect_trace(EXCEPTION_POINTERS* exception_ptrs, const std::type_info& type_info);
+         void maybe_collect_trace(_EXCEPTION_POINTERS* exception_ptrs, const std::type_info& type_info);
          template<typename E>
-         CPPTRACE_FORCE_NO_INLINE inline int exception_filter(EXCEPTION_POINTERS* exception_ptrs) {
+         CPPTRACE_FORCE_NO_INLINE inline int exception_filter(_EXCEPTION_POINTERS* exception_ptrs) {
              maybe_collect_trace(exception_ptrs, typeid(E));
              return EXCEPTION_CONTINUE_SEARCH;
          }

--- a/src/from_current.cpp
+++ b/src/from_current.cpp
@@ -14,6 +14,13 @@
 #include "logging.hpp"
 #include "unwind/unwind.hpp"
 
+#if IS_WINDOWS
+ #ifndef WIN32_LEAN_AND_MEAN
+  #define WIN32_LEAN_AND_MEAN
+ #endif
+ #include <windows.h>
+#endif
+
 #ifndef _MSC_VER
  #include <cstring>
 #endif

--- a/test/unit/tracing/from_current.cpp
+++ b/test/unit/tracing/from_current.cpp
@@ -1,6 +1,10 @@
 #include <algorithm>
 #include <string>
 
+#ifdef _MSC_VER
+ #include <windows.h>
+#endif
+
 #include <gtest/gtest.h>
 #include <gtest/gtest-matchers.h>
 #include <gmock/gmock.h>


### PR DESCRIPTION
`windows.h` has a lot of transitive includes, and subsequently undesired macro definitions, that are not required for cpptrace's functionality. This change simply substitutes `windows.h` for `excpt.h` in `from_current.hpp`, fully isolating `windows.h` includes to cpptrace source files.

ctest passed locally on:
- msvc 19.50
- clang-cl 21.1.1